### PR TITLE
Translation using gettext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,6 +334,9 @@ ASALocalRun/
 # Local History for Visual Studio
 .localhistory/
 
+# Gettext model
+*.pot
+
 # Prerequisites
 *.d
 

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ sqlitecpp = dependency('SQLiteCpp')
 boost = dependency('boost')
 
 subdir('src')
+subdir('po')
 
 executable('org.nickvision.money', sources, dependencies: [threads, adwaita, jsoncpp, dl, sqlitecpp, boost], install: true)
 install_data(resources, install_dir: 'share/icons/hicolor/scalable/apps')

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -8,4 +8,5 @@ src/ui/views/accountview.cpp
 src/ui/views/groupdialog.cpp
 src/ui/views/mainwindow.cpp
 src/ui/views/preferencesdialog.cpp
+src/ui/views/shortcutsdialog.cpp
 src/ui/views/transactiondialog.cpp

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,0 +1,11 @@
+src/controllers/accountviewcontroller.cpp
+src/models/transaction.cpp
+src/ui/controls/comboboxdialog.cpp
+src/ui/controls/entrydialog.cpp
+src/ui/controls/grouprow.cpp
+src/ui/controls/transactionrow.cpp
+src/ui/views/accountview.cpp
+src/ui/views/groupdialog.cpp
+src/ui/views/mainwindow.cpp
+src/ui/views/preferencesdialog.cpp
+src/ui/views/transactiondialog.cpp

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,5 @@
+i18n = import('i18n')
+# define GETTEXT_PACKAGE and LOCALE_DIR
+add_project_arguments('-DGETTEXT_PACKAGE="' + meson.project_name() + '"', language:'cpp')
+add_project_arguments('-DLOCALE_DIR="' + join_paths(get_option('prefix'), get_option('localedir')) + '"', language:'cpp')
+i18n.gettext(meson.project_name())

--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -1,8 +1,10 @@
 #include "accountviewcontroller.hpp"
+#include "../utilities/string_format.hpp"
 #include <sstream>
 
 using namespace NickvisionMoney::Controllers;
 using namespace NickvisionMoney::Models;
+using namespace NickvisionMoney::Utilities;
 
 AccountViewController::AccountViewController(const std::string& path, const std::string& currencySymbol, bool displayCurrencySymbolOnRight, const std::function<void(const std::string& message)>& sendToastCallback) : m_currencySymbol{ currencySymbol }, m_displayCurrencySymbolOnRight{ displayCurrencySymbolOnRight }, m_account{ path }, m_sendToastCallback{ sendToastCallback }
 {
@@ -89,11 +91,11 @@ void AccountViewController::exportAsCSV(std::string& path)
     }
     if(m_account.exportAsCSV(path))
     {
-        m_sendToastCallback("Exported account to CSV successfully.");
+        m_sendToastCallback(_("Exported account to CSV successfully."));
     }
     else
     {
-        m_sendToastCallback("Unable to export account as CSV.");
+        m_sendToastCallback(_("Unable to export account as CSV."));
     }
 }
 

--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -1,5 +1,4 @@
 #include "accountviewcontroller.hpp"
-#include "../utilities/string_format.hpp"
 #include <sstream>
 
 using namespace NickvisionMoney::Controllers;
@@ -106,7 +105,7 @@ void AccountViewController::importFromCSV(std::string& path)
     {
         m_accountInfoChangedCallback();
     }
-    m_sendToastCallback("Imported " + std::to_string(imported) + " transactions from CSV.");
+    m_sendToastCallback(string_format(_("Imported %d transactions from CSV."), imported));
 }
 
 void AccountViewController::addGroup(const Group& group)

--- a/src/controllers/accountviewcontroller.hpp
+++ b/src/controllers/accountviewcontroller.hpp
@@ -9,6 +9,7 @@
 #include "../models/group.hpp"
 #include "../models/transaction.hpp"
 #include "../utilities/translation.hpp"
+#include "../utilities/string_format.hpp"
 
 namespace NickvisionMoney::Controllers
 {

--- a/src/controllers/accountviewcontroller.hpp
+++ b/src/controllers/accountviewcontroller.hpp
@@ -8,6 +8,7 @@
 #include "../models/account.hpp"
 #include "../models/group.hpp"
 #include "../models/transaction.hpp"
+#include "../utilities/translation.hpp"
 
 namespace NickvisionMoney::Controllers
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <libintl.h>
 #include "ui/application.hpp"
 
 using namespace NickvisionMoney::UI;
@@ -12,6 +13,11 @@ using namespace NickvisionMoney::UI;
  */
 int main(int argc, char* argv[])
 {
+    setlocale(LC_ALL, "");
+    bindtextdomain(GETTEXT_PACKAGE, LOCALE_DIR);
+    bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
+    textdomain(GETTEXT_PACKAGE);
+    
     Application app("org.nickvision.money");
     return app.run(argc, argv);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -44,7 +44,9 @@ sources = files('main.cpp',
 		'ui/views/preferencesdialog.hpp',
 		'ui/views/preferencesdialog.cpp',
 		'ui/views/shortcutsdialog.hpp',
-		'ui/views/shortcutsdialog.cpp')
+		'ui/views/shortcutsdialog.cpp',
+		'utilities/string_format.hpp',
+		'utilities/translation.hpp')
 
 resources = files('resources/org.nickvision.money.svg', 'resources/org.nickvision.money-devel.svg')
 resources_symbolic = files('resources/org.nickvision.money-symbolic.svg')

--- a/src/models/transaction.cpp
+++ b/src/models/transaction.cpp
@@ -51,31 +51,31 @@ std::string Transaction::getRepeatIntervalAsString() const
 {
     if(m_repeatInterval == RepeatInterval::Never)
     {
-        return "Never";
+        return _("Never");
     }
     else if(m_repeatInterval == RepeatInterval::Daily)
     {
-        return "Daily";
+        return _("Daily");
     }
     else if(m_repeatInterval == RepeatInterval::Weekly)
     {
-        return "Weekly";
+        return _("Weekly");
     }
     else if(m_repeatInterval == RepeatInterval::Monthly)
     {
-        return "Monthly";
+        return _("Monthly");
     }
     else if(m_repeatInterval == RepeatInterval::Quarterly)
     {
-        return "Quarterly";
+        return _("Quarterly");
     }
     else if(m_repeatInterval == RepeatInterval::Yearly)
     {
-        return "Yearly";
+        return _("Yearly");
     }
     else if(m_repeatInterval == RepeatInterval::Biyearly)
     {
-        return "Biyearly";
+        return _("Biyearly");
     }
     return "";
 }

--- a/src/models/transaction.hpp
+++ b/src/models/transaction.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/multiprecision/cpp_dec_float.hpp>
+#include "../utilities/translation.hpp"
 
 namespace NickvisionMoney::Models
 {

--- a/src/ui/application.cpp
+++ b/src/ui/application.cpp
@@ -12,7 +12,7 @@ Application::Application(const std::string& id, GApplicationFlags flags) : m_adw
     m_appInfo.setId(id);
     m_appInfo.setName("Nickvision Money");
     m_appInfo.setShortName("Money");
-    m_appInfo.setDescription("A personal finance manager.");
+    m_appInfo.setDescription(_("A personal finance manager."));
     m_appInfo.setVersion("2022.11.0-next");
     m_appInfo.setChangelog("<ul><li></li></ul>");
     m_appInfo.setGitHubRepo("https://github.com/nlogozzo/NickvisionMoney");

--- a/src/ui/application.hpp
+++ b/src/ui/application.hpp
@@ -6,6 +6,7 @@
 #include "views/mainwindow.hpp"
 #include "../models/appinfo.hpp"
 #include "../models/configuration.hpp"
+#include "../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI
 {

--- a/src/ui/controls/comboboxdialog.cpp
+++ b/src/ui/controls/comboboxdialog.cpp
@@ -6,7 +6,7 @@ ComboBoxDialog::ComboBoxDialog(GtkWindow* parent, const std::string& title, cons
 {
     //Dialog Settings
     gtk_window_set_hide_on_close(GTK_WINDOW(m_gobj), true);
-    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", "Cancel", "ok", "OK", nullptr);
+    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", _("Cancel"), "ok", _("OK"), nullptr);
     adw_message_dialog_set_response_appearance(ADW_MESSAGE_DIALOG(m_gobj), "ok", ADW_RESPONSE_SUGGESTED);
     adw_message_dialog_set_default_response(ADW_MESSAGE_DIALOG(m_gobj), "cancel");
     adw_message_dialog_set_close_response(ADW_MESSAGE_DIALOG(m_gobj), "cancel");

--- a/src/ui/controls/comboboxdialog.hpp
+++ b/src/ui/controls/comboboxdialog.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <adwaita.h>
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Controls
 {

--- a/src/ui/controls/entrydialog.cpp
+++ b/src/ui/controls/entrydialog.cpp
@@ -6,7 +6,7 @@ EntryDialog::EntryDialog(GtkWindow* parent, const std::string& title, const std:
 {
     //Dialog Settings
     gtk_window_set_hide_on_close(GTK_WINDOW(m_gobj), true);
-    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", "Cancel", "ok", "OK", nullptr);
+    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", _("Cancel"), "ok", _("OK"), nullptr);
     adw_message_dialog_set_response_appearance(ADW_MESSAGE_DIALOG(m_gobj), "ok", ADW_RESPONSE_SUGGESTED);
     adw_message_dialog_set_default_response(ADW_MESSAGE_DIALOG(m_gobj), "cancel");
     adw_message_dialog_set_close_response(ADW_MESSAGE_DIALOG(m_gobj), "cancel");

--- a/src/ui/controls/entrydialog.hpp
+++ b/src/ui/controls/entrydialog.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <adwaita.h>
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Controls
 {

--- a/src/ui/controls/grouprow.cpp
+++ b/src/ui/controls/grouprow.cpp
@@ -27,7 +27,7 @@ GroupRow::GroupRow(const Group& group, const std::string& currencySymbol, bool d
     gtk_widget_set_valign(m_btnEdit, GTK_ALIGN_CENTER);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnEdit), "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnEdit), "edit-symbolic");
-    gtk_widget_set_tooltip_text(m_btnEdit, "Edit Group");
+    gtk_widget_set_tooltip_text(m_btnEdit, _("Edit Group"));
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_gobj), m_btnEdit);
     g_signal_connect(m_btnEdit, "clicked", G_CALLBACK((void (*)(GtkButton*, gpointer))[](GtkButton*, gpointer data) { reinterpret_cast<GroupRow*>(data)->onEdit(); }), this);
     //Delete Button
@@ -35,7 +35,7 @@ GroupRow::GroupRow(const Group& group, const std::string& currencySymbol, bool d
     gtk_widget_set_valign(m_btnDelete, GTK_ALIGN_CENTER);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnDelete), "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnDelete), "user-trash-symbolic");
-    gtk_widget_set_tooltip_text(m_btnDelete, "Delete Group");
+    gtk_widget_set_tooltip_text(m_btnDelete, _("Delete Group"));
     g_signal_connect(m_btnDelete, "clicked", G_CALLBACK((void (*)(GtkButton*, gpointer))[](GtkButton*, gpointer data) { reinterpret_cast<GroupRow*>(data)->onDelete(); }), this);
     //Box
     m_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);

--- a/src/ui/controls/grouprow.hpp
+++ b/src/ui/controls/grouprow.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <adwaita.h>
 #include "../../models/group.hpp"
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Controls
 {

--- a/src/ui/controls/transactionrow.cpp
+++ b/src/ui/controls/transactionrow.cpp
@@ -16,7 +16,7 @@ TransactionRow::TransactionRow(const Transaction& transaction, const std::string
     builder << boost::gregorian::to_iso_extended_string(m_transaction.getDate());
     if(m_transaction.getRepeatInterval() != RepeatInterval::Never)
     {
-        builder << "\n" << "Repeat Interval: " << m_transaction.getRepeatIntervalAsString();
+        builder << "\n" << _("Repeat Interval: ") << m_transaction.getRepeatIntervalAsString();
     }
     adw_action_row_set_subtitle(ADW_ACTION_ROW(m_gobj), builder.str().c_str());
     //Amount Label
@@ -37,7 +37,7 @@ TransactionRow::TransactionRow(const Transaction& transaction, const std::string
     gtk_widget_set_valign(m_btnEdit, GTK_ALIGN_CENTER);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnEdit), "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnEdit), "edit-symbolic");
-    gtk_widget_set_tooltip_text(m_btnEdit, "Edit Transaction");
+    gtk_widget_set_tooltip_text(m_btnEdit, _("Edit Transaction"));
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_gobj), m_btnEdit);
     g_signal_connect(m_btnEdit, "clicked", G_CALLBACK((void (*)(GtkButton*, gpointer))[](GtkButton*, gpointer data) { reinterpret_cast<TransactionRow*>(data)->onEdit(); }), this);
     //Delete Button
@@ -45,7 +45,7 @@ TransactionRow::TransactionRow(const Transaction& transaction, const std::string
     gtk_widget_set_valign(m_btnDelete, GTK_ALIGN_CENTER);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnDelete), "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnDelete), "user-trash-symbolic");
-    gtk_widget_set_tooltip_text(m_btnDelete, "Delete Transaction");
+    gtk_widget_set_tooltip_text(m_btnDelete, _("Delete Transaction"));
     g_signal_connect(m_btnDelete, "clicked", G_CALLBACK((void (*)(GtkButton*, gpointer))[](GtkButton*, gpointer data) { reinterpret_cast<TransactionRow*>(data)->onDelete(); }), this);
     //Box
     m_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);

--- a/src/ui/controls/transactionrow.hpp
+++ b/src/ui/controls/transactionrow.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <adwaita.h>
 #include "../../models/transaction.hpp"
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Controls
 {

--- a/src/ui/views/accountview.cpp
+++ b/src/ui/views/accountview.cpp
@@ -14,7 +14,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     m_boxMain = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     //Account Total
     m_rowTotal = adw_expander_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTotal), "Total");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTotal), _("Total"));
     adw_expander_row_set_subtitle(ADW_EXPANDER_ROW(m_rowTotal), "");
     adw_expander_row_set_expanded(ADW_EXPANDER_ROW(m_rowTotal), true);
     //Account Income
@@ -22,7 +22,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_widget_set_valign(m_lblIncome, GTK_ALIGN_CENTER);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_lblIncome), "success");
     m_rowIncome = adw_action_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowIncome), "Income");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowIncome), _("Income"));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowIncome), m_lblIncome);
     adw_expander_row_add_row(ADW_EXPANDER_ROW(m_rowTotal), m_rowIncome);
     //Account Expense
@@ -30,7 +30,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_widget_set_valign(m_lblExpense, GTK_ALIGN_CENTER);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_lblExpense), "error");
     m_rowExpense = adw_action_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowExpense), "Expense");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowExpense), _("Expense"));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowExpense), m_lblExpense);
     adw_expander_row_add_row(ADW_EXPANDER_ROW(m_rowTotal), m_rowExpense);
     //Button Menu Account Actions
@@ -38,11 +38,11 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnMenuAccountActions), "flat");
     GtkWidget* btnMenuAccountActionsContent{ adw_button_content_new() };
     adw_button_content_set_icon_name(ADW_BUTTON_CONTENT(btnMenuAccountActionsContent), "document-properties-symbolic");
-    adw_button_content_set_label(ADW_BUTTON_CONTENT(btnMenuAccountActionsContent), "Actions");
+    adw_button_content_set_label(ADW_BUTTON_CONTENT(btnMenuAccountActionsContent), _("Actions"));
     gtk_menu_button_set_child(GTK_MENU_BUTTON(m_btnMenuAccountActions), btnMenuAccountActionsContent);
     GMenu* menuActions{ g_menu_new() };
-    g_menu_append(menuActions, "Export as CSV", "account.exportAsCSV");
-    g_menu_append(menuActions, "Import from CSV", "account.importFromCSV");
+    g_menu_append(menuActions, _("Export as CSV"), "account.exportAsCSV");
+    g_menu_append(menuActions, _("Import from CSV"), "account.importFromCSV");
     gtk_menu_button_set_menu_model(GTK_MENU_BUTTON(m_btnMenuAccountActions), G_MENU_MODEL(menuActions));
     g_object_unref(menuActions);
     //Overview Group
@@ -51,7 +51,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_widget_set_margin_top(m_grpOverview, 10);
     gtk_widget_set_margin_end(m_grpOverview, 30);
     gtk_widget_set_margin_bottom(m_grpOverview, 10);
-    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpOverview), "Overview");
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpOverview), _("Overview"));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpOverview), m_rowTotal);
     adw_preferences_group_set_header_suffix(ADW_PREFERENCES_GROUP(m_grpOverview), m_btnMenuAccountActions);
     gtk_box_append(GTK_BOX(m_boxMain), m_grpOverview);
@@ -60,8 +60,8 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewGroup), "flat");
     GtkWidget* btnNewGroupContent{ adw_button_content_new() };
     adw_button_content_set_icon_name(ADW_BUTTON_CONTENT(btnNewGroupContent), "list-add-symbolic");
-    adw_button_content_set_label(ADW_BUTTON_CONTENT(btnNewGroupContent), "New");
-    gtk_widget_set_tooltip_text(m_btnNewGroup, "New Group (Ctrl+G)");
+    adw_button_content_set_label(ADW_BUTTON_CONTENT(btnNewGroupContent), _("New"));
+    gtk_widget_set_tooltip_text(m_btnNewGroup, _("New Group (Ctrl+G)"));
     gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(m_btnNewGroup), "account.newGroup");
     gtk_button_set_child(GTK_BUTTON(m_btnNewGroup), btnNewGroupContent);
     //Groups Group
@@ -70,7 +70,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_widget_set_margin_top(m_grpGroups, 10);
     gtk_widget_set_margin_end(m_grpGroups, 30);
     gtk_widget_set_margin_bottom(m_grpGroups, 10);
-    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpGroups), "Groups");
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpGroups), _("Groups"));
     adw_preferences_group_set_header_suffix(ADW_PREFERENCES_GROUP(m_grpGroups), m_btnNewGroup);
     gtk_box_append(GTK_BOX(m_boxMain), m_grpGroups);
     //Button New Transaction
@@ -78,8 +78,8 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewTransaction), "flat");
     GtkWidget* btnNewTransactionContent{ adw_button_content_new() };
     adw_button_content_set_icon_name(ADW_BUTTON_CONTENT(btnNewTransactionContent), "list-add-symbolic");
-    adw_button_content_set_label(ADW_BUTTON_CONTENT(btnNewTransactionContent), "New");
-    gtk_widget_set_tooltip_text(m_btnNewTransaction, "New Transaction (Ctrl+Shift+N)");
+    adw_button_content_set_label(ADW_BUTTON_CONTENT(btnNewTransactionContent), _("New"));
+    gtk_widget_set_tooltip_text(m_btnNewTransaction, _("New Transaction (Ctrl+Shift+N)"));
     gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(m_btnNewTransaction), "account.newTransaction");
     gtk_button_set_child(GTK_BUTTON(m_btnNewTransaction), btnNewTransactionContent);
     //Transactions Group
@@ -88,7 +88,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_widget_set_margin_top(m_grpTransactions, 10);
     gtk_widget_set_margin_end(m_grpTransactions, 30);
     gtk_widget_set_margin_bottom(m_grpTransactions, 10);
-    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpTransactions), "Transactions");
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpTransactions), _("Transactions"));
     adw_preferences_group_set_header_suffix(ADW_PREFERENCES_GROUP(m_grpTransactions), m_btnNewTransaction);
     gtk_box_append(GTK_BOX(m_boxMain), m_grpTransactions);
     //Main Layout
@@ -173,7 +173,7 @@ void AccountView::onAccountInfoChanged()
 
 void AccountView::onExportAsCSV()
 {
-    GtkFileChooserNative* saveFileDialog{ gtk_file_chooser_native_new("Export as CSV", m_parentWindow, GTK_FILE_CHOOSER_ACTION_SAVE, "_Save", "_Cancel") };
+    GtkFileChooserNative* saveFileDialog{ gtk_file_chooser_native_new(_("Export as CSV"), m_parentWindow, GTK_FILE_CHOOSER_ACTION_SAVE, _("_Save"), _("_Cancel")) };
     gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(saveFileDialog), true);
     GtkFileFilter* filter{ gtk_file_filter_new() };
     gtk_file_filter_set_name(filter, "CSV (*.csv)");
@@ -197,7 +197,7 @@ void AccountView::onExportAsCSV()
 
 void AccountView::onImportFromCSV()
 {
-    GtkFileChooserNative* openFileDialog{ gtk_file_chooser_native_new("Import from CSV", m_parentWindow, GTK_FILE_CHOOSER_ACTION_OPEN, "_Open", "_Cancel") };
+    GtkFileChooserNative* openFileDialog{ gtk_file_chooser_native_new(_("Import from CSV"), m_parentWindow, GTK_FILE_CHOOSER_ACTION_OPEN, _("_Open"), _("_Cancel")) };
     gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(openFileDialog), true);
     GtkFileFilter* filter{ gtk_file_filter_new() };
     gtk_file_filter_set_name(filter, "CSV (*.csv)");
@@ -241,7 +241,7 @@ void AccountView::onEditGroup(unsigned int id)
 
 void AccountView::onDeleteGroup(unsigned int id)
 {
-    MessageDialog messageDialog{ m_parentWindow, "Delete Group?", "Are you sure you want to delete this group?\nThis action is irreversible.", "No", "Yes" };
+    MessageDialog messageDialog{ m_parentWindow, _("Delete Group?"), _("Are you sure you want to delete this group?\nThis action is irreversible."), _("No"), _("Yes") };
     if(messageDialog.run() == MessageDialogResponse::Destructive)
     {
         m_controller.deleteGroup(id);
@@ -270,7 +270,7 @@ void AccountView::onEditTransaction(unsigned int id)
 
 void AccountView::onDeleteTransaction(unsigned int id)
 {
-    MessageDialog messageDialog{ m_parentWindow, "Delete Transaction?", "Are you sure you want to delete this transaction?\nThis action is irreversible.", "No", "Yes" };
+    MessageDialog messageDialog{ m_parentWindow, _("Delete Transaction?"), _("Are you sure you want to delete this transaction?\nThis action is irreversible."), _("No"), _("Yes") };
     if(messageDialog.run() == MessageDialogResponse::Destructive)
     {
         m_controller.deleteTransaction(id);

--- a/src/ui/views/accountview.hpp
+++ b/src/ui/views/accountview.hpp
@@ -6,6 +6,7 @@
 #include "../controls/grouprow.hpp"
 #include "../controls/transactionrow.hpp"
 #include "../../controllers/accountviewcontroller.hpp"
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Views
 {

--- a/src/ui/views/groupdialog.cpp
+++ b/src/ui/views/groupdialog.cpp
@@ -7,7 +7,7 @@ GroupDialog::GroupDialog(GtkWindow* parent, NickvisionMoney::Controllers::GroupD
 {
     //Dialog Settings
     gtk_window_set_hide_on_close(GTK_WINDOW(m_gobj), true);
-    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", "Cancel", "ok", "OK", nullptr);
+    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", _("Cancel"), "ok", _("OK"), nullptr);
     adw_message_dialog_set_response_appearance(ADW_MESSAGE_DIALOG(m_gobj), "ok", ADW_RESPONSE_SUGGESTED);
     adw_message_dialog_set_default_response(ADW_MESSAGE_DIALOG(m_gobj), "ok");
     adw_message_dialog_set_close_response(ADW_MESSAGE_DIALOG(m_gobj), "cancel");
@@ -17,13 +17,13 @@ GroupDialog::GroupDialog(GtkWindow* parent, NickvisionMoney::Controllers::GroupD
     //Name
     m_rowName = adw_entry_row_new();
     gtk_widget_set_size_request(m_rowName, 420, -1);
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), "Name");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), _("Name"));
     adw_entry_row_set_activates_default(ADW_ENTRY_ROW(m_rowName), true);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowName);
     //Description
     m_rowDescription = adw_entry_row_new();
     gtk_widget_set_size_request(m_rowDescription, 420, -1);
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), "Description");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description"));
     adw_entry_row_set_activates_default(ADW_ENTRY_ROW(m_rowDescription), true);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowDescription);
     //Layout
@@ -55,19 +55,19 @@ bool GroupDialog::run()
         {
             //Reset UI
             gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowName), "error");
-            adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), "Name");
+            adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), _("Name"));
             gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowDescription), "error");
-            adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), "Description");
+            adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description"));
             //Mark Error
             if(status == GroupCheckStatus::EmptyName)
             {
                 gtk_style_context_add_class(gtk_widget_get_style_context(m_rowName), "error");
-                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), "Name (Empty)");
+                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), _("Name (Empty)"));
             }
             else if(status == GroupCheckStatus::EmptyDescription)
             {
                 gtk_style_context_add_class(gtk_widget_get_style_context(m_rowDescription), "error");
-                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), "Description (Empty)");
+                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description (Empty)"));
             }
             return run();
         }

--- a/src/ui/views/groupdialog.hpp
+++ b/src/ui/views/groupdialog.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <adwaita.h>
 #include "../../controllers/groupdialogcontroller.hpp"
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Views
 {

--- a/src/ui/views/mainwindow.cpp
+++ b/src/ui/views/mainwindow.cpp
@@ -21,23 +21,23 @@ MainWindow::MainWindow(GtkApplication* application, const MainWindowController& 
     //Menu Account Button
     m_btnMenuAccount = gtk_menu_button_new();
     GMenu* menuAccount{ g_menu_new() };
-    g_menu_append(menuAccount, "New Account", "win.newAccount");
-    g_menu_append(menuAccount, "Open Account", "win.openAccount");
-    g_menu_append(menuAccount, "Close Account", "win.closeAccount");
+    g_menu_append(menuAccount, _("New Account"), "win.newAccount");
+    g_menu_append(menuAccount, _("Open Account"), "win.openAccount");
+    g_menu_append(menuAccount, _("Close Account"), "win.closeAccount");
     gtk_menu_button_set_icon_name(GTK_MENU_BUTTON(m_btnMenuAccount), "bank-symbolic");
     gtk_menu_button_set_menu_model(GTK_MENU_BUTTON(m_btnMenuAccount), G_MENU_MODEL(menuAccount));
-    gtk_widget_set_tooltip_text(m_btnMenuAccount, "Account Menu");
+    gtk_widget_set_tooltip_text(m_btnMenuAccount, _("Account Menu"));
     adw_header_bar_pack_start(ADW_HEADER_BAR(m_headerBar), m_btnMenuAccount);
     g_object_unref(menuAccount);
     //Menu Help Button
     m_btnMenuHelp = gtk_menu_button_new();
     GMenu* menuHelp{ g_menu_new() };
-    g_menu_append(menuHelp, "Preferences", "win.preferences");
-    g_menu_append(menuHelp, "Keyboard Shortcuts", "win.keyboardShortcuts");
-    g_menu_append(menuHelp, std::string("About " + m_controller.getAppInfo().getShortName()).c_str(), "win.about");
+    g_menu_append(menuHelp, _("Preferences"), "win.preferences");
+    g_menu_append(menuHelp, _("Keyboard Shortcuts"), "win.keyboardShortcuts");
+    g_menu_append(menuHelp, std::string(_("About ") + m_controller.getAppInfo().getShortName()).c_str(), "win.about");
     gtk_menu_button_set_direction(GTK_MENU_BUTTON(m_btnMenuHelp), GTK_ARROW_NONE);
     gtk_menu_button_set_menu_model(GTK_MENU_BUTTON(m_btnMenuHelp), G_MENU_MODEL(menuHelp));
-    gtk_widget_set_tooltip_text(m_btnMenuHelp, "Main Menu");
+    gtk_widget_set_tooltip_text(m_btnMenuHelp, _("Main Menu"));
     adw_header_bar_pack_end(ADW_HEADER_BAR(m_headerBar), m_btnMenuHelp);
     g_object_unref(menuHelp);
     //Toast Overlay
@@ -52,7 +52,7 @@ MainWindow::MainWindow(GtkApplication* application, const MainWindowController& 
     gtk_widget_set_size_request(m_btnNewAccount, 200, 50);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewAccount), "circular");
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewAccount), "suggested-action");
-    gtk_button_set_label(GTK_BUTTON(m_btnNewAccount), "New Account");
+    gtk_button_set_label(GTK_BUTTON(m_btnNewAccount), _("New Account"));
     gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(m_btnNewAccount), "win.newAccount");
     gtk_box_append(GTK_BOX(m_boxStatusButtons), m_btnNewAccount);
     //Open Account Button
@@ -60,14 +60,14 @@ MainWindow::MainWindow(GtkApplication* application, const MainWindowController& 
     gtk_widget_set_halign(m_btnOpenAccount, GTK_ALIGN_CENTER);
     gtk_widget_set_size_request(m_btnOpenAccount, 200, 50);
     gtk_style_context_add_class(gtk_widget_get_style_context(m_btnOpenAccount), "circular");
-    gtk_button_set_label(GTK_BUTTON(m_btnOpenAccount), "Open Account");
+    gtk_button_set_label(GTK_BUTTON(m_btnOpenAccount), _("Open Account"));
     gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(m_btnOpenAccount), "win.openAccount");
     gtk_box_append(GTK_BOX(m_boxStatusButtons), m_btnOpenAccount);
     //Page No Downloads
     m_pageStatusNoAccounts = adw_status_page_new();
     adw_status_page_set_icon_name(ADW_STATUS_PAGE(m_pageStatusNoAccounts), "org.nickvision.money-symbolic");
-    adw_status_page_set_title(ADW_STATUS_PAGE(m_pageStatusNoAccounts), "No Accounts Open");
-    adw_status_page_set_description(ADW_STATUS_PAGE(m_pageStatusNoAccounts), "Open or create an account to get started.");
+    adw_status_page_set_title(ADW_STATUS_PAGE(m_pageStatusNoAccounts), _("No Accounts Open"));
+    adw_status_page_set_description(ADW_STATUS_PAGE(m_pageStatusNoAccounts), _("Open or create an account to get started."));
     adw_status_page_set_child(ADW_STATUS_PAGE(m_pageStatusNoAccounts), m_boxStatusButtons);
     //Page Tabs
     m_pageTabs = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -151,10 +151,10 @@ void MainWindow::onAccountAdded()
 
 void MainWindow::onNewAccount()
 {
-    GtkFileChooserNative* saveFileDialog{ gtk_file_chooser_native_new("Open Account", GTK_WINDOW(m_gobj), GTK_FILE_CHOOSER_ACTION_SAVE, "_Save", "_Cancel") };
+    GtkFileChooserNative* saveFileDialog{ gtk_file_chooser_native_new(_("Open Account"), GTK_WINDOW(m_gobj), GTK_FILE_CHOOSER_ACTION_SAVE, _("_Save"), _("_Cancel")) };
     gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(saveFileDialog), true);
     GtkFileFilter* filter{ gtk_file_filter_new() };
-    gtk_file_filter_set_name(filter, "Money Account (*.nmoney)");
+    gtk_file_filter_set_name(filter, _("Money Account (*.nmoney)"));
     gtk_file_filter_add_pattern(filter, "*.nmoney");
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(saveFileDialog), filter);
     g_object_unref(filter);
@@ -175,10 +175,10 @@ void MainWindow::onNewAccount()
 
 void MainWindow::onOpenAccount()
 {
-    GtkFileChooserNative* openFileDialog{ gtk_file_chooser_native_new("Open Account", GTK_WINDOW(m_gobj), GTK_FILE_CHOOSER_ACTION_OPEN, "_Open", "_Cancel") };
+    GtkFileChooserNative* openFileDialog{ gtk_file_chooser_native_new(_("Open Account"), GTK_WINDOW(m_gobj), GTK_FILE_CHOOSER_ACTION_OPEN, _("_Open"), _("_Cancel")) };
     gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(openFileDialog), true);
     GtkFileFilter* filter{ gtk_file_filter_new() };
-    gtk_file_filter_set_name(filter, "Money Account (*.nmoney)");
+    gtk_file_filter_set_name(filter, _("Money Account (*.nmoney)"));
     gtk_file_filter_add_pattern(filter, "*.nmoney");
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(openFileDialog), filter);
     g_object_unref(filter);

--- a/src/ui/views/mainwindow.hpp
+++ b/src/ui/views/mainwindow.hpp
@@ -5,6 +5,7 @@
 #include <adwaita.h>
 #include "accountview.hpp"
 #include "../../controllers/mainwindowcontroller.hpp"
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Views
 {

--- a/src/ui/views/preferencesdialog.cpp
+++ b/src/ui/views/preferencesdialog.cpp
@@ -21,8 +21,7 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     //Theme Row
     m_rowTheme = adw_combo_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTheme), _("Theme"));
-    // TODO: Extract list to make it translatable
-    adw_combo_row_set_model(ADW_COMBO_ROW(m_rowTheme), G_LIST_MODEL(gtk_string_list_new(new const char*[4]{ "System", "Light", "Dark", nullptr })));
+    adw_combo_row_set_model(ADW_COMBO_ROW(m_rowTheme), G_LIST_MODEL(gtk_string_list_new(new const char*[4]{ _("System"), _("Light"), _("Dark"), nullptr })));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTheme);
     g_signal_connect(m_rowTheme, "notify::selected-item", G_CALLBACK((void (*)(GObject*, GParamSpec*, gpointer))[](GObject*, GParamSpec*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onThemeChanged(); }), this);
     //Currency Group

--- a/src/ui/views/preferencesdialog.cpp
+++ b/src/ui/views/preferencesdialog.cpp
@@ -13,31 +13,32 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     gtk_window_set_hide_on_close(GTK_WINDOW(m_gobj), true);
     //Header Bar
     m_headerBar = adw_header_bar_new();
-    adw_header_bar_set_title_widget(ADW_HEADER_BAR(m_headerBar), adw_window_title_new("Preferences", nullptr));
+    adw_header_bar_set_title_widget(ADW_HEADER_BAR(m_headerBar), adw_window_title_new(_("Preferences"), nullptr));
     //User Interface Group
     m_grpUserInterface = adw_preferences_group_new();
-    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpUserInterface), "User Interface");
-    adw_preferences_group_set_description(ADW_PREFERENCES_GROUP(m_grpUserInterface), "Customize the application's user interface.");
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpUserInterface), _("User Interface"));
+    adw_preferences_group_set_description(ADW_PREFERENCES_GROUP(m_grpUserInterface), _("Customize the application's user interface."));
     //Theme Row
     m_rowTheme = adw_combo_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTheme), "Theme");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTheme), _("Theme"));
+    // TODO: Extract list to make it translatable
     adw_combo_row_set_model(ADW_COMBO_ROW(m_rowTheme), G_LIST_MODEL(gtk_string_list_new(new const char*[4]{ "System", "Light", "Dark", nullptr })));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTheme);
     g_signal_connect(m_rowTheme, "notify::selected-item", G_CALLBACK((void (*)(GObject*, GParamSpec*, gpointer))[](GObject*, GParamSpec*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onThemeChanged(); }), this);
     //Currency Group
     m_grpCurrency = adw_preferences_group_new();
-    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpCurrency), "Currency");
-    adw_preferences_group_set_description(ADW_PREFERENCES_GROUP(m_grpCurrency), "Customize currency settings.\n\nA change in one of these settings will only be applied on newly opened accounts.");
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(m_grpCurrency), _("Currency"));
+    adw_preferences_group_set_description(ADW_PREFERENCES_GROUP(m_grpCurrency), _("Customize currency settings.\n\nA change in one of these settings will only be applied on newly opened accounts."));
     //Currency Symbol Row
     m_rowCurrencySymbol = adw_entry_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowCurrencySymbol), "Currency Symbol");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowCurrencySymbol), _("Currency Symbol"));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpCurrency), m_rowCurrencySymbol);
     //Display Currency Symbol On Right Row
     m_rowDisplayCurrencySymbolOnRight = adw_action_row_new();
     m_switchDisplayCurrencySymbolOnRight = gtk_switch_new();
     gtk_widget_set_valign(m_switchDisplayCurrencySymbolOnRight, GTK_ALIGN_CENTER);
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDisplayCurrencySymbolOnRight), "Display Currency Symbol On Right");
-    adw_action_row_set_subtitle(ADW_ACTION_ROW(m_rowDisplayCurrencySymbolOnRight), "If checked, the currency symbol will be displayed on the right of a monetary value.");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDisplayCurrencySymbolOnRight), _("Display Currency Symbol On Right"));
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(m_rowDisplayCurrencySymbolOnRight), _("If checked, the currency symbol will be displayed on the right of a monetary value."));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowDisplayCurrencySymbolOnRight), m_switchDisplayCurrencySymbolOnRight);
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_rowDisplayCurrencySymbolOnRight), m_switchDisplayCurrencySymbolOnRight);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpCurrency), m_rowDisplayCurrencySymbolOnRight);

--- a/src/ui/views/preferencesdialog.hpp
+++ b/src/ui/views/preferencesdialog.hpp
@@ -2,6 +2,7 @@
 
 #include <adwaita.h>
 #include "../../controllers/preferencesdialogcontroller.hpp"
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Views
 {

--- a/src/ui/views/shortcutsdialog.cpp
+++ b/src/ui/views/shortcutsdialog.cpp
@@ -1,95 +1,110 @@
 #include "shortcutsdialog.hpp"
+#include "../../utilities/string_format.hpp"
 
 using namespace NickvisionMoney::UI::Views;
+using namespace NickvisionMoney::Utilities;
 
 ShortcutsDialog::ShortcutsDialog(GtkWindow* parent)
 {
-    // TODO: Split the XML to access the text
-    m_xml = R"(
-    <?xml version="1.0" encoding="UTF-8"?>
-    <interface>
-        <object class="GtkShortcutsWindow" id="m_dialog">
-            <property name="default-width">600</property>
-            <property name="default-height">500</property>
-            <property name="modal">true</property>
-            <property name="resizable">true</property>
-            <property name="destroy-with-parent">false</property>
-            <property name="hide-on-close">true</property>
-            <child>
-                <object class="GtkShortcutsSection">
-                    <child>
-                        <object class="GtkShortcutsGroup">
-                            <property name="title">Account</property>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">New Account</property>
-                                    <property name="accelerator">&lt;Control&gt;N</property>
-                                </object>
-                            </child>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">Open Account</property>
-                                    <property name="accelerator">&lt;Control&gt;O</property>
-                                </object>
-                            </child>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">Close Account</property>
-                                    <property name="accelerator">&lt;Control&gt;W</property>
-                                </object>
-                            </child>
-                        </object>
-                    </child>
-                    <child>
-                        <object class="GtkShortcutsGroup">
-                            <property name="title">Group</property>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">New Group</property>
-                                    <property name="accelerator">&lt;Control&gt;G</property>
-                                </object>
-                            </child>
-                        </object>
-                    </child>
-                    <child>
-                        <object class="GtkShortcutsGroup">
-                            <property name="title">Transaction</property>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">New Transaction</property>
-                                    <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;N</property>
-                                </object>
-                            </child>
-                        </object>
-                    </child>
-                    <child>
-                        <object class="GtkShortcutsGroup">
-                            <property name="title">Application</property>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">Preferences</property>
-                                    <property name="accelerator">&lt;Control&gt;comma</property>
-                                </object>
-                            </child>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">Keyboard Shortcuts</property>
-                                    <property name="accelerator">&lt;Control&gt;question</property>
-                                </object>
-                            </child>
-                            <child>
-                                <object class="GtkShortcutsShortcut">
-                                    <property name="title">About</property>
-                                    <property name="accelerator">F1</property>
-                                </object>
-                            </child>
-                        </object>
-                    </child>
-                </object>
-            </child>
-        </object>
-    </interface>
-    )";
+    m_xml = string_format(
+        R"(
+        <?xml version="1.0" encoding="UTF-8"?>
+        <interface>
+            <object class="GtkShortcutsWindow" id="m_dialog">
+                <property name="default-width">600</property>
+                <property name="default-height">500</property>
+                <property name="modal">true</property>
+                <property name="resizable">true</property>
+                <property name="destroy-with-parent">false</property>
+                <property name="hide-on-close">true</property>
+                <child>
+                    <object class="GtkShortcutsSection">
+                        <child>
+                            <object class="GtkShortcutsGroup">
+                                <property name="title">%s</property>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">&lt;Control&gt;N</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">&lt;Control&gt;O</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">&lt;Control&gt;W</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkShortcutsGroup">
+                                <property name="title">%s</property>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">&lt;Control&gt;G</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkShortcutsGroup">
+                                <property name="title">%s</property>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;N</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkShortcutsGroup">
+                                <property name="title">%s</property>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">&lt;Control&gt;comma</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">&lt;Control&gt;question</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkShortcutsShortcut">
+                                        <property name="title">%s</property>
+                                        <property name="accelerator">F1</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+            </object>
+        </interface>
+        )",
+        _("Account"),
+        _("New Account"),
+        _("Open Account"),
+        _("Close Account"),
+        _("Group"),
+        _("New Group"),
+        _("Transaction"),
+        _("New Transaction"),
+        _("Application"),
+        _("Preferences"),
+        _("Keyboard Shortcuts"),
+        _("About")
+    );
     GtkBuilder* builder{ gtk_builder_new_from_string(m_xml.c_str(), -1) };
     m_gobj = GTK_WIDGET(gtk_builder_get_object(builder, "m_dialog"));
     gtk_window_set_transient_for(GTK_WINDOW(m_gobj), GTK_WINDOW(parent));

--- a/src/ui/views/shortcutsdialog.cpp
+++ b/src/ui/views/shortcutsdialog.cpp
@@ -4,6 +4,7 @@ using namespace NickvisionMoney::UI::Views;
 
 ShortcutsDialog::ShortcutsDialog(GtkWindow* parent)
 {
+    // TODO: Split the XML to access the text
     m_xml = R"(
     <?xml version="1.0" encoding="UTF-8"?>
     <interface>

--- a/src/ui/views/shortcutsdialog.hpp
+++ b/src/ui/views/shortcutsdialog.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <adwaita.h>
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Views
 {

--- a/src/ui/views/transactiondialog.cpp
+++ b/src/ui/views/transactiondialog.cpp
@@ -45,13 +45,12 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, NickvisionMoney::Control
     //Type
     m_rowType = adw_combo_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowType), _("Type"));
-    // TODO: Extract list to make is translatable
-    adw_combo_row_set_model(ADW_COMBO_ROW(m_rowType), G_LIST_MODEL(gtk_string_list_new(new const char*[3]{ "Income", "Expense", nullptr })));
+    adw_combo_row_set_model(ADW_COMBO_ROW(m_rowType), G_LIST_MODEL(gtk_string_list_new(new const char*[3]{ _("Income"), _("Expense"), nullptr })));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowType);
     //Repeat Interval
     m_rowRepeatInterval = adw_combo_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowRepeatInterval), _("Repeat Interval"));
-    adw_combo_row_set_model(ADW_COMBO_ROW(m_rowRepeatInterval), G_LIST_MODEL(gtk_string_list_new(new const char*[8]{ "Never", "Daily", "Weekly", "Monthly", "Quarterly", "Yearly", "Biyearly", nullptr })));
+    adw_combo_row_set_model(ADW_COMBO_ROW(m_rowRepeatInterval), G_LIST_MODEL(gtk_string_list_new(new const char*[8]{ _("Never"), _("Daily"), _("Weekly"), _("Monthly"), _("Quarterly"), _("Yearly"), _("Biyearly"), nullptr })));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowRepeatInterval);
     //Amount
     m_rowAmount = adw_entry_row_new();

--- a/src/ui/views/transactiondialog.cpp
+++ b/src/ui/views/transactiondialog.cpp
@@ -7,7 +7,7 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, NickvisionMoney::Control
 {
     //Dialog Settings
     gtk_window_set_hide_on_close(GTK_WINDOW(m_gobj), true);
-    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", "Cancel", "ok", "OK", nullptr);
+    adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(m_gobj), "cancel", _("Cancel"), "ok", _("OK"), nullptr);
     adw_message_dialog_set_response_appearance(ADW_MESSAGE_DIALOG(m_gobj), "ok", ADW_RESPONSE_SUGGESTED);
     adw_message_dialog_set_default_response(ADW_MESSAGE_DIALOG(m_gobj), "ok");
     adw_message_dialog_set_close_response(ADW_MESSAGE_DIALOG(m_gobj), "cancel");
@@ -32,24 +32,25 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, NickvisionMoney::Control
     gtk_menu_button_set_label(GTK_MENU_BUTTON(m_btnDate), g_date_time_format(gtk_calendar_get_date(GTK_CALENDAR(m_calendarDate)), "%Y-%m-%d"));
     m_rowDate = adw_action_row_new();
     gtk_widget_set_size_request(m_rowDate, 420, -1);
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDate), "Date");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDate), _("Date"));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowDate), m_btnDate);
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_rowDate), m_btnDate);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowDate);
     //Description
     m_rowDescription = adw_entry_row_new();
     gtk_widget_set_size_request(m_rowDescription, 420, -1);
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), "Description");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description"));
     adw_entry_row_set_activates_default(ADW_ENTRY_ROW(m_rowDescription), true);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowDescription);
     //Type
     m_rowType = adw_combo_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowType), "Type");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowType), _("Type"));
+    // TODO: Extract list to make is translatable
     adw_combo_row_set_model(ADW_COMBO_ROW(m_rowType), G_LIST_MODEL(gtk_string_list_new(new const char*[3]{ "Income", "Expense", nullptr })));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowType);
     //Repeat Interval
     m_rowRepeatInterval = adw_combo_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowRepeatInterval), "Repeat Interval");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowRepeatInterval), _("Repeat Interval"));
     adw_combo_row_set_model(ADW_COMBO_ROW(m_rowRepeatInterval), G_LIST_MODEL(gtk_string_list_new(new const char*[8]{ "Never", "Daily", "Weekly", "Monthly", "Quarterly", "Yearly", "Biyearly", nullptr })));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowRepeatInterval);
     //Amount
@@ -91,24 +92,24 @@ bool TransactionDialog::run()
         {
             //Reset UI
             gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowDescription), "error");
-            adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), "Description");
+            adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description"));
             gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowAmount), "error");
             adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), std::string("Amount (" + m_controller.getCurrencySymbol() + ")").c_str());
             //Mark Error
             if(status == TransactionCheckStatus::EmptyDescription)
             {
                 gtk_style_context_add_class(gtk_widget_get_style_context(m_rowDescription), "error");
-                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), "Description (Empty)");
+                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description (Empty)"));
             }
             else if(status == TransactionCheckStatus::EmptyAmount)
             {
                 gtk_style_context_add_class(gtk_widget_get_style_context(m_rowAmount), "error");
-                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), "Amount (Empty)");
+                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), _("Amount (Empty)"));
             }
             else if(status == TransactionCheckStatus::InvalidAmount)
             {
                 gtk_style_context_add_class(gtk_widget_get_style_context(m_rowAmount), "error");
-                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), "Amount (Invalid)");
+                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), _("Amount (Invalid)"));
             }
             return run();
         }

--- a/src/ui/views/transactiondialog.cpp
+++ b/src/ui/views/transactiondialog.cpp
@@ -2,6 +2,7 @@
 
 using namespace NickvisionMoney::Controllers;
 using namespace NickvisionMoney::UI::Views;
+using namespace NickvisionMoney::Utilities;
 
 TransactionDialog::TransactionDialog(GtkWindow* parent, NickvisionMoney::Controllers::TransactionDialogController& controller) : m_controller{ controller }, m_gobj{ adw_message_dialog_new(parent, "Transaction", nullptr) }
 {
@@ -17,7 +18,7 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, NickvisionMoney::Control
     //Id
     m_rowId = adw_entry_row_new();
     gtk_widget_set_size_request(m_rowId, 420, -1);
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowId), "ID");
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowId), _("ID"));
     gtk_editable_set_editable(GTK_EDITABLE(m_rowId), false);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowId);
     //Date
@@ -55,7 +56,7 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, NickvisionMoney::Control
     //Amount
     m_rowAmount = adw_entry_row_new();
     gtk_widget_set_size_request(m_rowAmount, 420, -1);
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), std::string("Amount (" + m_controller.getCurrencySymbol() + ")").c_str());
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), string_format(_("Amount (%s)"), m_controller.getCurrencySymbol().c_str()).c_str());
     adw_entry_row_set_activates_default(ADW_ENTRY_ROW(m_rowAmount), true);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_preferencesGroup), m_rowAmount);
     //Layout

--- a/src/ui/views/transactiondialog.hpp
+++ b/src/ui/views/transactiondialog.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <adwaita.h>
 #include "../../controllers/transactiondialogcontroller.hpp"
+#include "../../utilities/translation.hpp"
 
 namespace NickvisionMoney::UI::Views
 {

--- a/src/ui/views/transactiondialog.hpp
+++ b/src/ui/views/transactiondialog.hpp
@@ -4,6 +4,7 @@
 #include <adwaita.h>
 #include "../../controllers/transactiondialogcontroller.hpp"
 #include "../../utilities/translation.hpp"
+#include "../../utilities/string_format.hpp"
 
 namespace NickvisionMoney::UI::Views
 {

--- a/src/utilities/string_format.hpp
+++ b/src/utilities/string_format.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <stdexcept>
+
+namespace NickvisionMoney::Utilities
+{
+    /**
+     * Formats a string similarly to sprintf in C
+     *
+     * @param format The source string
+     * @param args The arguments to be added
+     * @returns The formatted string
+     */
+    template <typename... Args>
+    std::string string_format(const std::string &format, Args... args) {
+        int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
+        if (size_s <= 0)
+        {
+            throw std::runtime_error("Error during formatting.");
+        }
+        auto size = static_cast<size_t>(size_s);
+        std::unique_ptr<char[]> buf(new char[size]);
+        std::snprintf(buf.get(), size, format.c_str(), args...);
+        return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
+    }
+}

--- a/src/utilities/translation.hpp
+++ b/src/utilities/translation.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#include <libintl.h>
+#define _(String) gettext(String)


### PR DESCRIPTION
# What?
Added support for internationalization using GNU gettext and .po files, as suggested in #1 

# How?
This version adds support for gettext directly within meson, and allows to compile the following useful targets :
 - `org.nickvision.money-pot`: creates a .pot file, a model used by translators to create their .po files
 - `org.nickvision.money-update-po`: updates existing .po files by automatically adding new entries to be translated while keeping the other entries safe
All the other targets can be shown by running `meson introspect --targets` and compilation can be done by running `meson compile <target>`

Inside the code, each string containing displayed text is now wrapped with `_(...)` macro. Whenever the string was too large (like the XML string for shortcuts) or was split using concatenation, I used a new formatting function which acts like sprintf in C but converts back to native C++ strings.

Finally, each file using gettext is manually added to the po/POTFILES to ensure that .po files are updated correctly.

A lot of files have been modified, but it is mainly because of wrapping strings with the gettext function and adding the proper header. Here are the files that deserves to be looked :
 - **src/utilities/string_format.hpp**: new string formatting function
 - **src/utilities/translation.hpp**: header file for the gettext function
 - **src/ui/views/shortcutsdialog.cpp**, **src/controllers/accountviewcontroller.cpp** and **src/ui/views/transactiondialog.cpp**: implementing at some point `string_format`
 - **meson.build** and **po/meson.build**: i18n dependency addition

# What to do next?
This version doesn't support for international date format (dd/mm/yyyy for instance) and does not allow to translate the about page, as it is generated by adwaita.

# Screenshots
Here's an example of a french translation which I'd love to share once i18n is fully integrated to Money:
![Screenshot](https://imgur.com/6yVrOXe.png)