### PR TITLE
support for translator credits, updated po files for new 'translator-credits' string

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.money\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-06 18:53+0100\n"
+"POT-Creation-Date: 2022-11-07 23:15+0530\n"
 "PO-Revision-Date: 2022-11-06 10:02+0100\n"
 "Last-Translator: Enzo MAROS <enzo.maros@gmail.com>\n"
 "Language: fr\n"
@@ -33,31 +33,31 @@ msgstr "%d transaction importées depuis le CSV"
 msgid "None"
 msgstr "Aucun"
 
-#: src/models/transaction.cpp:55 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:55 src/ui/views/transactiondialog.cpp:56
 msgid "Never"
 msgstr "Jamais"
 
-#: src/models/transaction.cpp:59 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:59 src/ui/views/transactiondialog.cpp:56
 msgid "Daily"
 msgstr "Quotidienne"
 
-#: src/models/transaction.cpp:63 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:63 src/ui/views/transactiondialog.cpp:56
 msgid "Weekly"
 msgstr "Hebdomadaire"
 
-#: src/models/transaction.cpp:67 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:67 src/ui/views/transactiondialog.cpp:56
 msgid "Monthly"
 msgstr "Mensuelle"
 
-#: src/models/transaction.cpp:71 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:71 src/ui/views/transactiondialog.cpp:56
 msgid "Quarterly"
 msgstr "Trimestrielle"
 
-#: src/models/transaction.cpp:75 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:75 src/ui/views/transactiondialog.cpp:56
 msgid "Yearly"
 msgstr "Annuelle"
 
-#: src/models/transaction.cpp:79 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:79 src/ui/views/transactiondialog.cpp:56
 msgid "Biyearly"
 msgstr "Semestrielle"
 
@@ -66,12 +66,12 @@ msgid "A personal finance manager."
 msgstr "Gestionnaire des dépenses personnelles."
 
 #: src/ui/controls/comboboxdialog.cpp:10 src/ui/controls/entrydialog.cpp:10
-#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:14
+#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:13
 msgid "Cancel"
 msgstr "Annuler"
 
 #: src/ui/controls/comboboxdialog.cpp:10 src/ui/controls/entrydialog.cpp:10
-#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:14
+#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:13
 msgid "OK"
 msgstr "OK"
 
@@ -95,80 +95,80 @@ msgstr "Modifier la transaction"
 msgid "Delete Transaction"
 msgstr "Supprimer la transaction"
 
-#: src/ui/views/accountview.cpp:19
+#: src/ui/views/accountview.cpp:18
 msgid "Total"
 msgstr "Total"
 
-#: src/ui/views/accountview.cpp:27
+#: src/ui/views/accountview.cpp:26
 msgctxt "Overview"
 msgid "Income"
 msgstr "Crédit"
 
-#: src/ui/views/accountview.cpp:35
+#: src/ui/views/accountview.cpp:34
 msgctxt "Overview"
 msgid "Expense"
 msgstr "Débit"
 
-#: src/ui/views/accountview.cpp:43
+#: src/ui/views/accountview.cpp:42
 msgid "Actions"
 msgstr "Actions"
 
-#: src/ui/views/accountview.cpp:46 src/ui/views/accountview.cpp:178
+#: src/ui/views/accountview.cpp:45 src/ui/views/accountview.cpp:177
 msgid "Export as CSV"
 msgstr "Exporter au format CSV"
 
-#: src/ui/views/accountview.cpp:47 src/ui/views/accountview.cpp:202
+#: src/ui/views/accountview.cpp:46 src/ui/views/accountview.cpp:201
 msgid "Import from CSV"
 msgstr "Importer depuis un CSV"
 
-#: src/ui/views/accountview.cpp:56
+#: src/ui/views/accountview.cpp:55
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
-#: src/ui/views/accountview.cpp:65
+#: src/ui/views/accountview.cpp:64
 msgctxt "Group"
 msgid "New"
 msgstr "Nouveau"
 
-#: src/ui/views/accountview.cpp:66
+#: src/ui/views/accountview.cpp:65
 msgid "New Group (Ctrl+G)"
 msgstr "Nouveau groupe (Ctrl+G)"
 
-#: src/ui/views/accountview.cpp:75
+#: src/ui/views/accountview.cpp:74
 msgid "Groups"
 msgstr "Groupes"
 
-#: src/ui/views/accountview.cpp:83
+#: src/ui/views/accountview.cpp:82
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nouveau"
 
-#: src/ui/views/accountview.cpp:84
+#: src/ui/views/accountview.cpp:83
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nouvelle transaction (Ctrl+Maj+N)"
 
-#: src/ui/views/accountview.cpp:93
+#: src/ui/views/accountview.cpp:92
 msgid "Transactions"
 msgstr "Transactions"
 
-#: src/ui/views/accountview.cpp:178 src/ui/views/mainwindow.cpp:157
+#: src/ui/views/accountview.cpp:177 src/ui/views/mainwindow.cpp:157
 msgid "_Save"
 msgstr "_Enregistrer"
 
-#: src/ui/views/accountview.cpp:178 src/ui/views/accountview.cpp:202
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:177 src/ui/views/accountview.cpp:201
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
 msgid "_Cancel"
 msgstr "_Annuler"
 
-#: src/ui/views/accountview.cpp:202 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:201 src/ui/views/mainwindow.cpp:185
 msgid "_Open"
 msgstr "_Ouvrir"
 
-#: src/ui/views/accountview.cpp:246
+#: src/ui/views/accountview.cpp:245
 msgid "Delete Group?"
 msgstr "Supprimer le groupe ?"
 
-#: src/ui/views/accountview.cpp:246
+#: src/ui/views/accountview.cpp:245
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -176,19 +176,19 @@ msgstr ""
 "Êtes-vous sûr de vouloir supprimer ce groupe ?\n"
 "Cette action est irréversible."
 
-#: src/ui/views/accountview.cpp:246 src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:245 src/ui/views/accountview.cpp:274
 msgid "No"
 msgstr "Non"
 
-#: src/ui/views/accountview.cpp:246 src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:245 src/ui/views/accountview.cpp:274
 msgid "Yes"
 msgstr "Oui"
 
-#: src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:274
 msgid "Delete Transaction?"
 msgstr "Supprimer la transaction ?"
 
-#: src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:274
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -196,7 +196,7 @@ msgstr ""
 "Êtes-vous sûr de vouloir supprimer cette transaction ?\n"
 "Cette action est irréversible."
 
-#: src/ui/views/groupdialog.cpp:7 src/ui/views/transactiondialog.cpp:61
+#: src/ui/views/groupdialog.cpp:7 src/ui/views/transactiondialog.cpp:60
 msgid "Group"
 msgstr "Groupe"
 
@@ -205,7 +205,7 @@ msgid "Name"
 msgstr "Nom"
 
 #: src/ui/views/groupdialog.cpp:27 src/ui/views/groupdialog.cpp:61
-#: src/ui/views/transactiondialog.cpp:46 src/ui/views/transactiondialog.cpp:110
+#: src/ui/views/transactiondialog.cpp:45 src/ui/views/transactiondialog.cpp:109
 msgid "Description"
 msgstr "Description"
 
@@ -213,22 +213,22 @@ msgstr "Description"
 msgid "Name (Empty)"
 msgstr "Nom (vide)"
 
-#: src/ui/views/groupdialog.cpp:71 src/ui/views/transactiondialog.cpp:117
+#: src/ui/views/groupdialog.cpp:71 src/ui/views/transactiondialog.cpp:116
 msgid "Description (Empty)"
 msgstr "Description (vide)"
 
 #: src/ui/views/mainwindow.cpp:27 src/ui/views/mainwindow.cpp:58
-#: src/ui/views/shortcutsdialog.cpp:97
+#: src/ui/views/shortcutsdialog.cpp:96
 msgid "New Account"
 msgstr "Nouveau compte"
 
 #: src/ui/views/mainwindow.cpp:28 src/ui/views/mainwindow.cpp:66
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
-#: src/ui/views/shortcutsdialog.cpp:98
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
+#: src/ui/views/shortcutsdialog.cpp:97
 msgid "Open Account"
 msgstr "Ouvrir un compte"
 
-#: src/ui/views/mainwindow.cpp:29 src/ui/views/shortcutsdialog.cpp:99
+#: src/ui/views/mainwindow.cpp:29 src/ui/views/shortcutsdialog.cpp:98
 msgid "Close Account"
 msgstr "Fermer le compte"
 
@@ -237,11 +237,11 @@ msgid "Account Menu"
 msgstr "Menu des comptes"
 
 #: src/ui/views/mainwindow.cpp:38 src/ui/views/preferencesdialog.cpp:17
-#: src/ui/views/shortcutsdialog.cpp:105
+#: src/ui/views/shortcutsdialog.cpp:104
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/ui/views/mainwindow.cpp:39 src/ui/views/shortcutsdialog.cpp:106
+#: src/ui/views/mainwindow.cpp:39 src/ui/views/shortcutsdialog.cpp:105
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
@@ -262,9 +262,13 @@ msgstr "Aucun compte ouvert"
 msgid "Open or create an account to get started."
 msgstr "Ouvrez ou créez un compte pour commencer"
 
-#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:184
+#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:188
 msgid "Money Account (*.nmoney)"
 msgstr "Compte Money (*.nmoney)"
+
+#: src/ui/views/mainwindow.cpp:241
+msgid "translator-credits"
+msgstr ""
 
 #: src/ui/views/preferencesdialog.cpp:20
 msgid "User Interface"
@@ -321,70 +325,70 @@ msgstr ""
 "Quand cette option est cochée, le symbole monétaire apparaît à droite de la "
 "valeur."
 
-#: src/ui/views/shortcutsdialog.cpp:96
+#: src/ui/views/shortcutsdialog.cpp:95
 msgid "Account"
 msgstr "Compte"
 
-#: src/ui/views/shortcutsdialog.cpp:100
+#: src/ui/views/shortcutsdialog.cpp:99
 msgctxt "Shortcuts"
 msgid "Group"
 msgstr "Groupe"
 
-#: src/ui/views/shortcutsdialog.cpp:101
+#: src/ui/views/shortcutsdialog.cpp:100
 msgid "New Group"
 msgstr "Nouveau groupe"
 
-#: src/ui/views/shortcutsdialog.cpp:102 src/ui/views/transactiondialog.cpp:10
+#: src/ui/views/shortcutsdialog.cpp:101 src/ui/views/transactiondialog.cpp:9
 msgid "Transaction"
 msgstr "Transaction"
 
-#: src/ui/views/shortcutsdialog.cpp:103
+#: src/ui/views/shortcutsdialog.cpp:102
 msgid "New Transaction"
 msgstr "Nouvelle transaction"
 
-#: src/ui/views/shortcutsdialog.cpp:104
+#: src/ui/views/shortcutsdialog.cpp:103
 msgid "Application"
 msgstr "Application"
 
-#: src/ui/views/shortcutsdialog.cpp:107
+#: src/ui/views/shortcutsdialog.cpp:106
 msgid "About"
 msgstr "À propos"
 
-#: src/ui/views/transactiondialog.cpp:24
+#: src/ui/views/transactiondialog.cpp:23
 msgid "ID"
 msgstr "Identifiant"
 
-#: src/ui/views/transactiondialog.cpp:39
+#: src/ui/views/transactiondialog.cpp:38
 msgid "Date"
 msgstr "Date"
 
-#: src/ui/views/transactiondialog.cpp:51
+#: src/ui/views/transactiondialog.cpp:50
 msgid "Type"
 msgstr "Type"
 
-#: src/ui/views/transactiondialog.cpp:52
+#: src/ui/views/transactiondialog.cpp:51
 msgctxt "Transaction|Edition"
 msgid "Income"
 msgstr "Crédit"
 
-#: src/ui/views/transactiondialog.cpp:52
+#: src/ui/views/transactiondialog.cpp:51
 msgctxt "Transaction|Edition"
 msgid "Expense"
 msgstr "Débit"
 
-#: src/ui/views/transactiondialog.cpp:56
+#: src/ui/views/transactiondialog.cpp:55
 msgid "Repeat Interval"
 msgstr "Répéter à intervalle"
 
-#: src/ui/views/transactiondialog.cpp:73 src/ui/views/transactiondialog.cpp:112
+#: src/ui/views/transactiondialog.cpp:72 src/ui/views/transactiondialog.cpp:111
 #, c-format
 msgid "Amount (%s)"
 msgstr "Montant (%s)"
 
-#: src/ui/views/transactiondialog.cpp:122
+#: src/ui/views/transactiondialog.cpp:121
 msgid "Amount (Empty)"
 msgstr "Montant (vide)"
 
-#: src/ui/views/transactiondialog.cpp:127
+#: src/ui/views/transactiondialog.cpp:126
 msgid "Amount (Invalid)"
 msgstr "Montant (invalide)"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.money\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-07 00:18+0530\n"
+"POT-Creation-Date: 2022-11-07 23:15+0530\n"
 "PO-Revision-Date: 2022-11-06 08:43+0530\n"
 "Last-Translator: Hemish <hemish04082005@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -157,11 +157,11 @@ msgid "_Save"
 msgstr "_संचित करें (Save)"
 
 #: src/ui/views/accountview.cpp:177 src/ui/views/accountview.cpp:201
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
 msgid "_Cancel"
 msgstr "_रद्द (Cancel)"
 
-#: src/ui/views/accountview.cpp:201 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:201 src/ui/views/mainwindow.cpp:185
 msgid "_Open"
 msgstr "खोलें"
 
@@ -224,7 +224,7 @@ msgid "New Account"
 msgstr "नया खाता"
 
 #: src/ui/views/mainwindow.cpp:28 src/ui/views/mainwindow.cpp:66
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
 #: src/ui/views/shortcutsdialog.cpp:97
 msgid "Open Account"
 msgstr "खाता खोलें"
@@ -247,6 +247,7 @@ msgid "Keyboard Shortcuts"
 msgstr "कीबोर्ड शोर्टकत"
 
 #: src/ui/views/mainwindow.cpp:40
+#, c-format
 msgid "About %s"
 msgstr "%s के बारे में"
 
@@ -262,9 +263,13 @@ msgstr "कोई खाता नहीं खुला है"
 msgid "Open or create an account to get started."
 msgstr "आरंभ करने के लिए मौजूदा या नया खाता खोलें"
 
-#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:184
+#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:188
 msgid "Money Account (*.nmoney)"
 msgstr ""
+
+#: src/ui/views/mainwindow.cpp:241
+msgid "translator-credits"
+msgstr "Hemish <hemish04082005@gmail.com>"
 
 #: src/ui/views/preferencesdialog.cpp:20
 msgid "User Interface"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.money\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-06 23:08+0100\n"
+"POT-Creation-Date: 2022-11-07 23:15+0530\n"
 "PO-Revision-Date: 2022-11-06 23:12+0100\n"
 "Last-Translator: Mattia Borda <mattiagiovanni.borda@icloud.com>\n"
 "Language-Team: Italian <>\n"
@@ -159,11 +159,11 @@ msgid "_Save"
 msgstr "Salva"
 
 #: src/ui/views/accountview.cpp:177 src/ui/views/accountview.cpp:201
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
 msgid "_Cancel"
 msgstr "Annulla"
 
-#: src/ui/views/accountview.cpp:201 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:201 src/ui/views/mainwindow.cpp:185
 msgid "_Open"
 msgstr "Apri"
 
@@ -226,7 +226,7 @@ msgid "New Account"
 msgstr "Nuovo account"
 
 #: src/ui/views/mainwindow.cpp:28 src/ui/views/mainwindow.cpp:66
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
 #: src/ui/views/shortcutsdialog.cpp:97
 msgid "Open Account"
 msgstr "Apri account"
@@ -265,9 +265,13 @@ msgstr "Nessun account aperto"
 msgid "Open or create an account to get started."
 msgstr "Apri o crea un account per cominciare."
 
-#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:184
+#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:188
 msgid "Money Account (*.nmoney)"
 msgstr "Account Money (*.nmoney)"
+
+#: src/ui/views/mainwindow.cpp:241
+msgid "translator-credits"
+msgstr ""
 
 #: src/ui/views/preferencesdialog.cpp:20
 msgid "User Interface"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.money\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-06 18:53+0100\n"
+"POT-Creation-Date: 2022-11-07 23:15+0530\n"
 "PO-Revision-Date: 2022-11-06 20:40+0100\n"
 "Last-Translator: Marcin Wolski <martinwolski04@gmail.com>\n"
+"Language-Team: Polish <->\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language-Team: Polish <->\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2)\n"
 "X-Generator: Gtranslator 42.0\n"
@@ -38,31 +38,31 @@ msgstr "Transakcje w ilości %d zostały zaimportowane z CSV"
 msgid "None"
 msgstr "Brak"
 
-#: src/models/transaction.cpp:55 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:55 src/ui/views/transactiondialog.cpp:56
 msgid "Never"
 msgstr "Nigdy"
 
-#: src/models/transaction.cpp:59 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:59 src/ui/views/transactiondialog.cpp:56
 msgid "Daily"
 msgstr "Dzienne"
 
-#: src/models/transaction.cpp:63 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:63 src/ui/views/transactiondialog.cpp:56
 msgid "Weekly"
 msgstr "Tygodniowe"
 
-#: src/models/transaction.cpp:67 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:67 src/ui/views/transactiondialog.cpp:56
 msgid "Monthly"
 msgstr "Miesięczne"
 
-#: src/models/transaction.cpp:71 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:71 src/ui/views/transactiondialog.cpp:56
 msgid "Quarterly"
 msgstr "Kwartalne"
 
-#: src/models/transaction.cpp:75 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:75 src/ui/views/transactiondialog.cpp:56
 msgid "Yearly"
 msgstr "Roczne"
 
-#: src/models/transaction.cpp:79 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:79 src/ui/views/transactiondialog.cpp:56
 msgid "Biyearly"
 msgstr "Dwuletnie"
 
@@ -71,12 +71,12 @@ msgid "A personal finance manager."
 msgstr "Menadżer finansów osobistych."
 
 #: src/ui/controls/comboboxdialog.cpp:10 src/ui/controls/entrydialog.cpp:10
-#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:14
+#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:13
 msgid "Cancel"
 msgstr "Anuluj"
 
 #: src/ui/controls/comboboxdialog.cpp:10 src/ui/controls/entrydialog.cpp:10
-#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:14
+#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:13
 msgid "OK"
 msgstr "OK"
 
@@ -100,80 +100,80 @@ msgstr "Edytuj transakcję"
 msgid "Delete Transaction"
 msgstr "Usuń transakcję"
 
-#: src/ui/views/accountview.cpp:19
+#: src/ui/views/accountview.cpp:18
 msgid "Total"
 msgstr "Łącznie"
 
-#: src/ui/views/accountview.cpp:27
+#: src/ui/views/accountview.cpp:26
 msgctxt "Overview"
 msgid "Income"
 msgstr "Dochód"
 
-#: src/ui/views/accountview.cpp:35
+#: src/ui/views/accountview.cpp:34
 msgctxt "Overview"
 msgid "Expense"
 msgstr "Wydatek"
 
-#: src/ui/views/accountview.cpp:43
+#: src/ui/views/accountview.cpp:42
 msgid "Actions"
 msgstr "Akcje"
 
-#: src/ui/views/accountview.cpp:46 src/ui/views/accountview.cpp:178
+#: src/ui/views/accountview.cpp:45 src/ui/views/accountview.cpp:177
 msgid "Export as CSV"
 msgstr "Eksportuj jako CSV"
 
-#: src/ui/views/accountview.cpp:47 src/ui/views/accountview.cpp:202
+#: src/ui/views/accountview.cpp:46 src/ui/views/accountview.cpp:201
 msgid "Import from CSV"
 msgstr "Importuj z CSV"
 
-#: src/ui/views/accountview.cpp:56
+#: src/ui/views/accountview.cpp:55
 msgid "Overview"
 msgstr "Podsumowanie"
 
-#: src/ui/views/accountview.cpp:65
+#: src/ui/views/accountview.cpp:64
 msgctxt "Group"
 msgid "New"
 msgstr "Nowa"
 
-#: src/ui/views/accountview.cpp:66
+#: src/ui/views/accountview.cpp:65
 msgid "New Group (Ctrl+G)"
 msgstr "Nowa grupa (Ctrl+G)"
 
-#: src/ui/views/accountview.cpp:75
+#: src/ui/views/accountview.cpp:74
 msgid "Groups"
 msgstr "Grupy"
 
-#: src/ui/views/accountview.cpp:83
+#: src/ui/views/accountview.cpp:82
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nowa"
 
-#: src/ui/views/accountview.cpp:84
+#: src/ui/views/accountview.cpp:83
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nowa transakcja (Ctrl+Shift+N)"
 
-#: src/ui/views/accountview.cpp:93
+#: src/ui/views/accountview.cpp:92
 msgid "Transactions"
 msgstr "Transakcje"
 
-#: src/ui/views/accountview.cpp:178 src/ui/views/mainwindow.cpp:157
+#: src/ui/views/accountview.cpp:177 src/ui/views/mainwindow.cpp:157
 msgid "_Save"
 msgstr "_Zapisz"
 
-#: src/ui/views/accountview.cpp:178 src/ui/views/accountview.cpp:202
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:177 src/ui/views/accountview.cpp:201
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
 msgid "_Cancel"
 msgstr "_Anuluj"
 
-#: src/ui/views/accountview.cpp:202 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:201 src/ui/views/mainwindow.cpp:185
 msgid "_Open"
 msgstr "_Otwórz"
 
-#: src/ui/views/accountview.cpp:246
+#: src/ui/views/accountview.cpp:245
 msgid "Delete Group?"
 msgstr "Usunąć grupę?"
 
-#: src/ui/views/accountview.cpp:246
+#: src/ui/views/accountview.cpp:245
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -181,19 +181,19 @@ msgstr ""
 "Jesteś pewien, że chcesz usunąć tę grupę?\n"
 "Ta akcja jest nieodwracalna."
 
-#: src/ui/views/accountview.cpp:246 src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:245 src/ui/views/accountview.cpp:274
 msgid "No"
 msgstr "Nie"
 
-#: src/ui/views/accountview.cpp:246 src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:245 src/ui/views/accountview.cpp:274
 msgid "Yes"
 msgstr "Tak"
 
-#: src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:274
 msgid "Delete Transaction?"
 msgstr "Usunać transakcje?"
 
-#: src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:274
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -201,7 +201,7 @@ msgstr ""
 "Jesteś pewien, że chcesz usunąć tę transakcję?\n"
 "Ta akcja jest nieodwracalna."
 
-#: src/ui/views/groupdialog.cpp:7 src/ui/views/transactiondialog.cpp:61
+#: src/ui/views/groupdialog.cpp:7 src/ui/views/transactiondialog.cpp:60
 msgid "Group"
 msgstr "Grupa"
 
@@ -210,7 +210,7 @@ msgid "Name"
 msgstr "Nazwa"
 
 #: src/ui/views/groupdialog.cpp:27 src/ui/views/groupdialog.cpp:61
-#: src/ui/views/transactiondialog.cpp:46 src/ui/views/transactiondialog.cpp:110
+#: src/ui/views/transactiondialog.cpp:45 src/ui/views/transactiondialog.cpp:109
 msgid "Description"
 msgstr "Opis"
 
@@ -218,22 +218,22 @@ msgstr "Opis"
 msgid "Name (Empty)"
 msgstr "Nazwa (Brak)"
 
-#: src/ui/views/groupdialog.cpp:71 src/ui/views/transactiondialog.cpp:117
+#: src/ui/views/groupdialog.cpp:71 src/ui/views/transactiondialog.cpp:116
 msgid "Description (Empty)"
 msgstr "Opis (Brak)"
 
 #: src/ui/views/mainwindow.cpp:27 src/ui/views/mainwindow.cpp:58
-#: src/ui/views/shortcutsdialog.cpp:97
+#: src/ui/views/shortcutsdialog.cpp:96
 msgid "New Account"
 msgstr "Nowe konto"
 
 #: src/ui/views/mainwindow.cpp:28 src/ui/views/mainwindow.cpp:66
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
-#: src/ui/views/shortcutsdialog.cpp:98
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
+#: src/ui/views/shortcutsdialog.cpp:97
 msgid "Open Account"
 msgstr "Otwórz konto"
 
-#: src/ui/views/mainwindow.cpp:29 src/ui/views/shortcutsdialog.cpp:99
+#: src/ui/views/mainwindow.cpp:29 src/ui/views/shortcutsdialog.cpp:98
 msgid "Close Account"
 msgstr "Zamknij konto"
 
@@ -242,11 +242,11 @@ msgid "Account Menu"
 msgstr "Menu konta"
 
 #: src/ui/views/mainwindow.cpp:38 src/ui/views/preferencesdialog.cpp:17
-#: src/ui/views/shortcutsdialog.cpp:105
+#: src/ui/views/shortcutsdialog.cpp:104
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: src/ui/views/mainwindow.cpp:39 src/ui/views/shortcutsdialog.cpp:106
+#: src/ui/views/mainwindow.cpp:39 src/ui/views/shortcutsdialog.cpp:105
 msgid "Keyboard Shortcuts"
 msgstr "Skróty klawiszowe"
 
@@ -267,9 +267,13 @@ msgstr "Brak otwartych kont"
 msgid "Open or create an account to get started."
 msgstr "Otwórz, lub utwórz kontok, aby rozpocząć"
 
-#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:184
+#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:188
 msgid "Money Account (*.nmoney)"
 msgstr "Konto Money (*.nmoney)"
+
+#: src/ui/views/mainwindow.cpp:241
+msgid "translator-credits"
+msgstr ""
 
 #: src/ui/views/preferencesdialog.cpp:20
 msgid "User Interface"
@@ -326,70 +330,70 @@ msgstr ""
 "Jeśli zaznaczone, symbol waluty będzie wyświetlony po prawej stronie "
 "wartości pieniężnej"
 
-#: src/ui/views/shortcutsdialog.cpp:96
+#: src/ui/views/shortcutsdialog.cpp:95
 msgid "Account"
 msgstr "Konto"
 
-#: src/ui/views/shortcutsdialog.cpp:100
+#: src/ui/views/shortcutsdialog.cpp:99
 msgctxt "Shortcuts"
 msgid "Group"
 msgstr "Grupa"
 
-#: src/ui/views/shortcutsdialog.cpp:101
+#: src/ui/views/shortcutsdialog.cpp:100
 msgid "New Group"
 msgstr "Nowa grupa"
 
-#: src/ui/views/shortcutsdialog.cpp:102 src/ui/views/transactiondialog.cpp:10
+#: src/ui/views/shortcutsdialog.cpp:101 src/ui/views/transactiondialog.cpp:9
 msgid "Transaction"
 msgstr "Transakcja"
 
-#: src/ui/views/shortcutsdialog.cpp:103
+#: src/ui/views/shortcutsdialog.cpp:102
 msgid "New Transaction"
 msgstr "Nowa transakcja"
 
-#: src/ui/views/shortcutsdialog.cpp:104
+#: src/ui/views/shortcutsdialog.cpp:103
 msgid "Application"
 msgstr "Aplikacja"
 
-#: src/ui/views/shortcutsdialog.cpp:107
+#: src/ui/views/shortcutsdialog.cpp:106
 msgid "About"
 msgstr "O aplikacji"
 
-#: src/ui/views/transactiondialog.cpp:24
+#: src/ui/views/transactiondialog.cpp:23
 msgid "ID"
 msgstr "ID"
 
-#: src/ui/views/transactiondialog.cpp:39
+#: src/ui/views/transactiondialog.cpp:38
 msgid "Date"
 msgstr "Data"
 
-#: src/ui/views/transactiondialog.cpp:51
+#: src/ui/views/transactiondialog.cpp:50
 msgid "Type"
 msgstr "Typ"
 
-#: src/ui/views/transactiondialog.cpp:52
+#: src/ui/views/transactiondialog.cpp:51
 msgctxt "Transaction|Edition"
 msgid "Income"
 msgstr "Dochód"
 
-#: src/ui/views/transactiondialog.cpp:52
+#: src/ui/views/transactiondialog.cpp:51
 msgctxt "Transaction|Edition"
 msgid "Expense"
 msgstr "Wydatek"
 
-#: src/ui/views/transactiondialog.cpp:56
+#: src/ui/views/transactiondialog.cpp:55
 msgid "Repeat Interval"
 msgstr "Interwał powtórzeń"
 
-#: src/ui/views/transactiondialog.cpp:73 src/ui/views/transactiondialog.cpp:112
+#: src/ui/views/transactiondialog.cpp:72 src/ui/views/transactiondialog.cpp:111
 #, c-format
 msgid "Amount (%s)"
 msgstr "Kwota (%s)"
 
-#: src/ui/views/transactiondialog.cpp:122
+#: src/ui/views/transactiondialog.cpp:121
 msgid "Amount (Empty)"
 msgstr "Kwota (Brak)"
 
-#: src/ui/views/transactiondialog.cpp:127
+#: src/ui/views/transactiondialog.cpp:126
 msgid "Amount (Invalid)"
 msgstr "Kwota (Nieprawidłowa)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.money\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-06 18:53+0100\n"
+"POT-Creation-Date: 2022-11-07 23:15+0530\n"
 "PO-Revision-Date: 2022-11-06 21:46+0300\n"
 "Last-Translator: Fyodor Sobolev\n"
 "Language: ru\n"
@@ -33,31 +33,31 @@ msgstr "Импортировано транзакций из CSV: %d."
 msgid "None"
 msgstr "Нет"
 
-#: src/models/transaction.cpp:55 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:55 src/ui/views/transactiondialog.cpp:56
 msgid "Never"
 msgstr "Никогда"
 
-#: src/models/transaction.cpp:59 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:59 src/ui/views/transactiondialog.cpp:56
 msgid "Daily"
 msgstr "Ежедневно"
 
-#: src/models/transaction.cpp:63 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:63 src/ui/views/transactiondialog.cpp:56
 msgid "Weekly"
 msgstr "Еженедельно"
 
-#: src/models/transaction.cpp:67 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:67 src/ui/views/transactiondialog.cpp:56
 msgid "Monthly"
 msgstr "Ежемесячно"
 
-#: src/models/transaction.cpp:71 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:71 src/ui/views/transactiondialog.cpp:56
 msgid "Quarterly"
 msgstr "Каждый квартал"
 
-#: src/models/transaction.cpp:75 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:75 src/ui/views/transactiondialog.cpp:56
 msgid "Yearly"
 msgstr "Каждый год"
 
-#: src/models/transaction.cpp:79 src/ui/views/transactiondialog.cpp:57
+#: src/models/transaction.cpp:79 src/ui/views/transactiondialog.cpp:56
 msgid "Biyearly"
 msgstr "Раз в полгода"
 
@@ -66,12 +66,12 @@ msgid "A personal finance manager."
 msgstr "Персональный менеджер финансов."
 
 #: src/ui/controls/comboboxdialog.cpp:10 src/ui/controls/entrydialog.cpp:10
-#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:14
+#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:13
 msgid "Cancel"
 msgstr "Отмена"
 
 #: src/ui/controls/comboboxdialog.cpp:10 src/ui/controls/entrydialog.cpp:10
-#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:14
+#: src/ui/views/groupdialog.cpp:11 src/ui/views/transactiondialog.cpp:13
 msgid "OK"
 msgstr "ОК"
 
@@ -95,80 +95,80 @@ msgstr "Редактировать транзакцию"
 msgid "Delete Transaction"
 msgstr "Удалить транзакцию"
 
-#: src/ui/views/accountview.cpp:19
+#: src/ui/views/accountview.cpp:18
 msgid "Total"
 msgstr "Сумма"
 
-#: src/ui/views/accountview.cpp:27
+#: src/ui/views/accountview.cpp:26
 msgctxt "Overview"
 msgid "Income"
 msgstr "Доходы"
 
-#: src/ui/views/accountview.cpp:35
+#: src/ui/views/accountview.cpp:34
 msgctxt "Overview"
 msgid "Expense"
 msgstr "Расходы"
 
-#: src/ui/views/accountview.cpp:43
+#: src/ui/views/accountview.cpp:42
 msgid "Actions"
 msgstr "Действия"
 
-#: src/ui/views/accountview.cpp:46 src/ui/views/accountview.cpp:178
+#: src/ui/views/accountview.cpp:45 src/ui/views/accountview.cpp:177
 msgid "Export as CSV"
 msgstr "Экспорт в CSV"
 
-#: src/ui/views/accountview.cpp:47 src/ui/views/accountview.cpp:202
+#: src/ui/views/accountview.cpp:46 src/ui/views/accountview.cpp:201
 msgid "Import from CSV"
 msgstr "Импорт из CSV"
 
-#: src/ui/views/accountview.cpp:56
+#: src/ui/views/accountview.cpp:55
 msgid "Overview"
 msgstr "Обзор"
 
-#: src/ui/views/accountview.cpp:65
+#: src/ui/views/accountview.cpp:64
 msgctxt "Group"
 msgid "New"
 msgstr "Новая"
 
-#: src/ui/views/accountview.cpp:66
+#: src/ui/views/accountview.cpp:65
 msgid "New Group (Ctrl+G)"
 msgstr "Новая группа (Ctrl+G)"
 
-#: src/ui/views/accountview.cpp:75
+#: src/ui/views/accountview.cpp:74
 msgid "Groups"
 msgstr "Группы"
 
-#: src/ui/views/accountview.cpp:83
+#: src/ui/views/accountview.cpp:82
 msgctxt "Transaction"
 msgid "New"
 msgstr "Новая"
 
-#: src/ui/views/accountview.cpp:84
+#: src/ui/views/accountview.cpp:83
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Новая транзакция (Ctrl+Shift+N)"
 
-#: src/ui/views/accountview.cpp:93
+#: src/ui/views/accountview.cpp:92
 msgid "Transactions"
 msgstr "Транзакции"
 
-#: src/ui/views/accountview.cpp:178 src/ui/views/mainwindow.cpp:157
+#: src/ui/views/accountview.cpp:177 src/ui/views/mainwindow.cpp:157
 msgid "_Save"
 msgstr "_Сохранить"
 
-#: src/ui/views/accountview.cpp:178 src/ui/views/accountview.cpp:202
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:177 src/ui/views/accountview.cpp:201
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
 msgid "_Cancel"
 msgstr "_Отмена"
 
-#: src/ui/views/accountview.cpp:202 src/ui/views/mainwindow.cpp:181
+#: src/ui/views/accountview.cpp:201 src/ui/views/mainwindow.cpp:185
 msgid "_Open"
 msgstr "_Открыть"
 
-#: src/ui/views/accountview.cpp:246
+#: src/ui/views/accountview.cpp:245
 msgid "Delete Group?"
 msgstr "Удалить группу?"
 
-#: src/ui/views/accountview.cpp:246
+#: src/ui/views/accountview.cpp:245
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -176,19 +176,19 @@ msgstr ""
 "Уверены, что хотите удалить группу?\n"
 "Это действие необратимо."
 
-#: src/ui/views/accountview.cpp:246 src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:245 src/ui/views/accountview.cpp:274
 msgid "No"
 msgstr "Нет"
 
-#: src/ui/views/accountview.cpp:246 src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:245 src/ui/views/accountview.cpp:274
 msgid "Yes"
 msgstr "Да"
 
-#: src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:274
 msgid "Delete Transaction?"
 msgstr "Удалить транзакцию?"
 
-#: src/ui/views/accountview.cpp:275
+#: src/ui/views/accountview.cpp:274
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -196,7 +196,7 @@ msgstr ""
 "Уверены, что хотите удалить транзакцию?\n"
 "Это действие необратимо."
 
-#: src/ui/views/groupdialog.cpp:7 src/ui/views/transactiondialog.cpp:61
+#: src/ui/views/groupdialog.cpp:7 src/ui/views/transactiondialog.cpp:60
 msgid "Group"
 msgstr "Группа"
 
@@ -205,7 +205,7 @@ msgid "Name"
 msgstr "Имя"
 
 #: src/ui/views/groupdialog.cpp:27 src/ui/views/groupdialog.cpp:61
-#: src/ui/views/transactiondialog.cpp:46 src/ui/views/transactiondialog.cpp:110
+#: src/ui/views/transactiondialog.cpp:45 src/ui/views/transactiondialog.cpp:109
 msgid "Description"
 msgstr "Описание"
 
@@ -213,22 +213,22 @@ msgstr "Описание"
 msgid "Name (Empty)"
 msgstr "Имя (Пусто)"
 
-#: src/ui/views/groupdialog.cpp:71 src/ui/views/transactiondialog.cpp:117
+#: src/ui/views/groupdialog.cpp:71 src/ui/views/transactiondialog.cpp:116
 msgid "Description (Empty)"
 msgstr "Описание (Пусто)"
 
 #: src/ui/views/mainwindow.cpp:27 src/ui/views/mainwindow.cpp:58
-#: src/ui/views/shortcutsdialog.cpp:97
+#: src/ui/views/shortcutsdialog.cpp:96
 msgid "New Account"
 msgstr "Новый счёт"
 
 #: src/ui/views/mainwindow.cpp:28 src/ui/views/mainwindow.cpp:66
-#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:181
-#: src/ui/views/shortcutsdialog.cpp:98
+#: src/ui/views/mainwindow.cpp:157 src/ui/views/mainwindow.cpp:185
+#: src/ui/views/shortcutsdialog.cpp:97
 msgid "Open Account"
 msgstr "Открыть счёт"
 
-#: src/ui/views/mainwindow.cpp:29 src/ui/views/shortcutsdialog.cpp:99
+#: src/ui/views/mainwindow.cpp:29 src/ui/views/shortcutsdialog.cpp:98
 msgid "Close Account"
 msgstr "Закрыть счёт"
 
@@ -237,11 +237,11 @@ msgid "Account Menu"
 msgstr "Меню счёта"
 
 #: src/ui/views/mainwindow.cpp:38 src/ui/views/preferencesdialog.cpp:17
-#: src/ui/views/shortcutsdialog.cpp:105
+#: src/ui/views/shortcutsdialog.cpp:104
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/ui/views/mainwindow.cpp:39 src/ui/views/shortcutsdialog.cpp:106
+#: src/ui/views/mainwindow.cpp:39 src/ui/views/shortcutsdialog.cpp:105
 msgid "Keyboard Shortcuts"
 msgstr "Сочетания клавиш"
 
@@ -262,9 +262,13 @@ msgstr "Нет открытых счетов"
 msgid "Open or create an account to get started."
 msgstr "Откройте или создайте счёт, чтобы начать."
 
-#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:184
+#: src/ui/views/mainwindow.cpp:160 src/ui/views/mainwindow.cpp:188
 msgid "Money Account (*.nmoney)"
 msgstr "Счёт приложения Money (*.nmoney)"
+
+#: src/ui/views/mainwindow.cpp:241
+msgid "translator-credits"
+msgstr ""
 
 #: src/ui/views/preferencesdialog.cpp:20
 msgid "User Interface"
@@ -317,73 +321,72 @@ msgstr "Отображать символ валюты справа"
 msgid ""
 "If checked, the currency symbol will be displayed on the right of a monetary "
 "value."
-msgstr ""
-"Если включено, символ валюты будет отображаться справа от значения."
+msgstr "Если включено, символ валюты будет отображаться справа от значения."
 
-#: src/ui/views/shortcutsdialog.cpp:96
+#: src/ui/views/shortcutsdialog.cpp:95
 msgid "Account"
 msgstr "Счёт"
 
-#: src/ui/views/shortcutsdialog.cpp:100
+#: src/ui/views/shortcutsdialog.cpp:99
 msgctxt "Shortcuts"
 msgid "Group"
 msgstr "Группа"
 
-#: src/ui/views/shortcutsdialog.cpp:101
+#: src/ui/views/shortcutsdialog.cpp:100
 msgid "New Group"
 msgstr "Новая группа"
 
-#: src/ui/views/shortcutsdialog.cpp:102 src/ui/views/transactiondialog.cpp:10
+#: src/ui/views/shortcutsdialog.cpp:101 src/ui/views/transactiondialog.cpp:9
 msgid "Transaction"
 msgstr "Транзакция"
 
-#: src/ui/views/shortcutsdialog.cpp:103
+#: src/ui/views/shortcutsdialog.cpp:102
 msgid "New Transaction"
 msgstr "Новая транзакция"
 
-#: src/ui/views/shortcutsdialog.cpp:104
+#: src/ui/views/shortcutsdialog.cpp:103
 msgid "Application"
 msgstr "Приложение"
 
-#: src/ui/views/shortcutsdialog.cpp:107
+#: src/ui/views/shortcutsdialog.cpp:106
 msgid "About"
 msgstr "О приложении"
 
-#: src/ui/views/transactiondialog.cpp:24
+#: src/ui/views/transactiondialog.cpp:23
 msgid "ID"
 msgstr "Идентификатор (ID)"
 
-#: src/ui/views/transactiondialog.cpp:39
+#: src/ui/views/transactiondialog.cpp:38
 msgid "Date"
 msgstr "Дата"
 
-#: src/ui/views/transactiondialog.cpp:51
+#: src/ui/views/transactiondialog.cpp:50
 msgid "Type"
 msgstr "Тип"
 
-#: src/ui/views/transactiondialog.cpp:52
+#: src/ui/views/transactiondialog.cpp:51
 msgctxt "Transaction|Edition"
 msgid "Income"
 msgstr "Доход"
 
-#: src/ui/views/transactiondialog.cpp:52
+#: src/ui/views/transactiondialog.cpp:51
 msgctxt "Transaction|Edition"
 msgid "Expense"
 msgstr "Расход"
 
-#: src/ui/views/transactiondialog.cpp:56
+#: src/ui/views/transactiondialog.cpp:55
 msgid "Repeat Interval"
 msgstr "Повторять с интервалом"
 
-#: src/ui/views/transactiondialog.cpp:73 src/ui/views/transactiondialog.cpp:112
+#: src/ui/views/transactiondialog.cpp:72 src/ui/views/transactiondialog.cpp:111
 #, c-format
 msgid "Amount (%s)"
 msgstr "Сумма (%s)"
 
-#: src/ui/views/transactiondialog.cpp:122
+#: src/ui/views/transactiondialog.cpp:121
 msgid "Amount (Empty)"
 msgstr "Сумма (Пусто)"
 
-#: src/ui/views/transactiondialog.cpp:127
+#: src/ui/views/transactiondialog.cpp:126
 msgid "Amount (Invalid)"
 msgstr "Сумма (Некорректная)"

--- a/src/ui/views/mainwindow.cpp
+++ b/src/ui/views/mainwindow.cpp
@@ -238,6 +238,7 @@ void MainWindow::onAbout()
                           "developers", new const char*[3]{ "Nicholas Logozzo https://github.com/nlogozzo", "Contributors on GitHub ❤️ https://github.com/nlogozzo/NickvisionMoney/graphs/contributors", nullptr },
                           "designers", new const char*[2]{ "Nicholas Logozzo https://github.com/nlogozzo", nullptr },
                           "artists", new const char*[2]{ "David Lapshin https://github.com/daudix-UFO", nullptr },
+			  "translator-credits", _("translator-credits"),
                           "release-notes", m_controller.getAppInfo().getChangelog().c_str(),
                           nullptr);
 }


### PR DESCRIPTION
Most of gnome apps provide translator credits in the about section of app, and the new libadwaita about dialog also has support for that. Basically a new line is added in `src/ui/views/mainwindow.cpp`, which also adds a new string in the po files called "translator-credits" and the translators put their name(s) and website/email (as described in [https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AboutWindow.html](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AboutWindow.html). )

If the app is operated in English, it does not show any translator credits, but if it is opened in some other locale, it displays translator credits in credits section of about dialog like this:

![Screenshot from 2022-11-07 23-21-04](https://user-images.githubusercontent.com/74466492/200382017-000ccc90-80d8-4c50-a029-572b7d2af9f6.png)

This pull request also ran the `meson compile org.nickvision.money-update-po` which updated the existing `.po` files, so you may ask the existing translators to maybe put their credits here in this discussion thread, so that you maybe update them all at one time (instead of every translator creating a new pull for their credits)


