### PR TITLE
Removed deprecated Gtk.StyleContext

### DIFF
--- a/src/ui/controls/grouprow.cpp
+++ b/src/ui/controls/grouprow.cpp
@@ -22,11 +22,11 @@ GroupRow::GroupRow(const Group& group, const std::string& currencySymbol, bool d
         builder << currencySymbol << m_group.getBalance();
     }
     m_lblAmount = gtk_label_new(builder.str().c_str());
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_lblAmount), m_group.getBalance() >= 0 ? "success" : "error");
+    gtk_widget_add_css_class(m_lblAmount, m_group.getBalance() >= 0 ? "success" : "error");
     //Edit Button
     m_btnEdit = gtk_button_new();
     gtk_widget_set_valign(m_btnEdit, GTK_ALIGN_CENTER);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnEdit), "flat");
+    gtk_widget_add_css_class(m_btnEdit, "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnEdit), "edit-symbolic");
     gtk_widget_set_tooltip_text(m_btnEdit, _("Edit Group"));
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_gobj), m_btnEdit);
@@ -34,7 +34,7 @@ GroupRow::GroupRow(const Group& group, const std::string& currencySymbol, bool d
     //Delete Button
     m_btnDelete = gtk_button_new();
     gtk_widget_set_valign(m_btnDelete, GTK_ALIGN_CENTER);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnDelete), "flat");
+    gtk_widget_add_css_class(m_btnDelete, "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnDelete), "user-trash-symbolic");
     gtk_widget_set_tooltip_text(m_btnDelete, _("Delete Group"));
     g_signal_connect(m_btnDelete, "clicked", G_CALLBACK((void (*)(GtkButton*, gpointer))[](GtkButton*, gpointer data) { reinterpret_cast<GroupRow*>(data)->onDelete(); }), this);

--- a/src/ui/controls/transactionrow.cpp
+++ b/src/ui/controls/transactionrow.cpp
@@ -32,11 +32,11 @@ TransactionRow::TransactionRow(const Transaction& transaction, const std::string
         builder << currencySymbol << m_transaction.getAmount();
     }
     m_lblAmount = gtk_label_new(builder.str().c_str());
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_lblAmount), m_transaction.getType() == TransactionType::Income ? "success" : "error");
+    gtk_widget_add_css_class(m_lblAmount, m_transaction.getType() == TransactionType::Income ? "success" : "error");
     //Edit Button
     m_btnEdit = gtk_button_new();
     gtk_widget_set_valign(m_btnEdit, GTK_ALIGN_CENTER);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnEdit), "flat");
+    gtk_widget_add_css_class(m_btnEdit, "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnEdit), "edit-symbolic");
     gtk_widget_set_tooltip_text(m_btnEdit, _("Edit Transaction"));
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_gobj), m_btnEdit);
@@ -44,7 +44,7 @@ TransactionRow::TransactionRow(const Transaction& transaction, const std::string
     //Delete Button
     m_btnDelete = gtk_button_new();
     gtk_widget_set_valign(m_btnDelete, GTK_ALIGN_CENTER);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnDelete), "flat");
+    gtk_widget_add_css_class(m_btnDelete, "flat");
     gtk_button_set_icon_name(GTK_BUTTON(m_btnDelete), "user-trash-symbolic");
     gtk_widget_set_tooltip_text(m_btnDelete, _("Delete Transaction"));
     g_signal_connect(m_btnDelete, "clicked", G_CALLBACK((void (*)(GtkButton*, gpointer))[](GtkButton*, gpointer data) { reinterpret_cast<TransactionRow*>(data)->onDelete(); }), this);

--- a/src/ui/views/accountview.cpp
+++ b/src/ui/views/accountview.cpp
@@ -21,7 +21,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     //Account Income
     m_lblIncome = gtk_label_new("");
     gtk_widget_set_valign(m_lblIncome, GTK_ALIGN_CENTER);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_lblIncome), "success");
+    gtk_widget_add_css_class(m_lblIncome, "success");
     m_rowIncome = adw_action_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowIncome), pgettext("Overview", "Income"));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowIncome), m_lblIncome);
@@ -29,14 +29,14 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     //Account Expense
     m_lblExpense = gtk_label_new("");
     gtk_widget_set_valign(m_lblExpense, GTK_ALIGN_CENTER);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_lblExpense), "error");
+    gtk_widget_add_css_class(m_lblExpense, "error");
     m_rowExpense = adw_action_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowExpense), pgettext("Overview", "Expense"));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowExpense), m_lblExpense);
     adw_expander_row_add_row(ADW_EXPANDER_ROW(m_rowTotal), m_rowExpense);
     //Button Menu Account Actions
     m_btnMenuAccountActions = gtk_menu_button_new();
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnMenuAccountActions), "flat");
+    gtk_widget_add_css_class(m_btnMenuAccountActions, "flat");
     GtkWidget* btnMenuAccountActionsContent{ adw_button_content_new() };
     adw_button_content_set_icon_name(ADW_BUTTON_CONTENT(btnMenuAccountActionsContent), "document-properties-symbolic");
     adw_button_content_set_label(ADW_BUTTON_CONTENT(btnMenuAccountActionsContent), _("Actions"));
@@ -58,7 +58,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_box_append(GTK_BOX(m_boxMain), m_grpOverview);
     //Button New Group
     m_btnNewGroup = gtk_button_new();
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewGroup), "flat");
+    gtk_widget_add_css_class(m_btnNewGroup, "flat");
     GtkWidget* btnNewGroupContent{ adw_button_content_new() };
     adw_button_content_set_icon_name(ADW_BUTTON_CONTENT(btnNewGroupContent), "list-add-symbolic");
     adw_button_content_set_label(ADW_BUTTON_CONTENT(btnNewGroupContent), pgettext("Group", "New"));
@@ -76,7 +76,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, con
     gtk_box_append(GTK_BOX(m_boxMain), m_grpGroups);
     //Button New Transaction
     m_btnNewTransaction = gtk_button_new();
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewTransaction), "flat");
+    gtk_widget_add_css_class(m_btnNewTransaction, "flat");
     GtkWidget* btnNewTransactionContent{ adw_button_content_new() };
     adw_button_content_set_icon_name(ADW_BUTTON_CONTENT(btnNewTransactionContent), "list-add-symbolic");
     adw_button_content_set_label(ADW_BUTTON_CONTENT(btnNewTransactionContent), pgettext("Transaction", "New"));

--- a/src/ui/views/groupdialog.cpp
+++ b/src/ui/views/groupdialog.cpp
@@ -55,19 +55,19 @@ bool GroupDialog::run()
         if(status != GroupCheckStatus::Valid)
         {
             //Reset UI
-            gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowName), "error");
+            gtk_widget_remove_css_class(m_rowName, "error");
             adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), _("Name"));
-            gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowDescription), "error");
+            gtk_widget_remove_css_class(m_rowDescription, "error");
             adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description"));
             //Mark Error
             if(status == GroupCheckStatus::EmptyName)
             {
-                gtk_style_context_add_class(gtk_widget_get_style_context(m_rowName), "error");
+                gtk_widget_add_css_class(m_rowName, "error");
                 adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowName), _("Name (Empty)"));
             }
             else if(status == GroupCheckStatus::EmptyDescription)
             {
-                gtk_style_context_add_class(gtk_widget_get_style_context(m_rowDescription), "error");
+                gtk_widget_add_css_class(m_rowDescription, "error");
                 adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description (Empty)"));
             }
             return run();

--- a/src/ui/views/mainwindow.cpp
+++ b/src/ui/views/mainwindow.cpp
@@ -15,7 +15,7 @@ MainWindow::MainWindow(GtkApplication* application, const MainWindowController& 
     gtk_window_set_default_size(GTK_WINDOW(m_gobj), 900, 700);
     if(m_controller.getIsDevVersion())
     {
-        gtk_style_context_add_class(gtk_widget_get_style_context(m_gobj), "devel");
+        gtk_widget_add_css_class(m_gobj, "devel");
     }
     //Header Bar
     m_headerBar = adw_header_bar_new();
@@ -53,8 +53,8 @@ MainWindow::MainWindow(GtkApplication* application, const MainWindowController& 
     m_btnNewAccount = gtk_button_new();
     gtk_widget_set_halign(m_btnNewAccount, GTK_ALIGN_CENTER);
     gtk_widget_set_size_request(m_btnNewAccount, 200, 50);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewAccount), "circular");
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnNewAccount), "suggested-action");
+    gtk_widget_add_css_class(m_btnNewAccount, "circular");
+    gtk_widget_add_css_class(m_btnNewAccount, "suggested-action");
     gtk_button_set_label(GTK_BUTTON(m_btnNewAccount), _("New Account"));
     gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(m_btnNewAccount), "win.newAccount");
     gtk_box_append(GTK_BOX(m_boxStatusButtons), m_btnNewAccount);
@@ -62,7 +62,7 @@ MainWindow::MainWindow(GtkApplication* application, const MainWindowController& 
     m_btnOpenAccount = gtk_button_new();
     gtk_widget_set_halign(m_btnOpenAccount, GTK_ALIGN_CENTER);
     gtk_widget_set_size_request(m_btnOpenAccount, 200, 50);
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnOpenAccount), "circular");
+    gtk_widget_add_css_class(m_btnOpenAccount, "circular");
     gtk_button_set_label(GTK_BUTTON(m_btnOpenAccount), _("Open Account"));
     gtk_actionable_set_detailed_action_name(GTK_ACTIONABLE(m_btnOpenAccount), "win.openAccount");
     gtk_box_append(GTK_BOX(m_boxStatusButtons), m_btnOpenAccount);

--- a/src/ui/views/transactiondialog.cpp
+++ b/src/ui/views/transactiondialog.cpp
@@ -29,7 +29,7 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, NickvisionMoney::Control
     m_popoverDate = gtk_popover_new();
     gtk_popover_set_child(GTK_POPOVER(m_popoverDate), m_calendarDate);
     m_btnDate = gtk_menu_button_new();
-    gtk_style_context_add_class(gtk_widget_get_style_context(m_btnDate), "flat");
+    gtk_widget_add_css_class(m_btnDate, "flat");
     gtk_widget_set_valign(m_btnDate, GTK_ALIGN_CENTER);
     gtk_menu_button_set_popover(GTK_MENU_BUTTON(m_btnDate), m_popoverDate);
     gtk_menu_button_set_label(GTK_MENU_BUTTON(m_btnDate), g_date_time_format(gtk_calendar_get_date(GTK_CALENDAR(m_calendarDate)), "%Y-%m-%d"));
@@ -105,24 +105,24 @@ bool TransactionDialog::run()
         if(status != TransactionCheckStatus::Valid)
         {
             //Reset UI
-            gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowDescription), "error");
+            gtk_widget_remove_css_class(m_rowDescription, "error");
             adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description"));
-            gtk_style_context_remove_class(gtk_widget_get_style_context(m_rowAmount), "error");
+            gtk_widget_remove_css_class(m_rowAmount, "error");
             adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), StringHelpers::format(_("Amount (%s)"), m_controller.getCurrencySymbol().c_str()).c_str());
             //Mark Error
             if(status == TransactionCheckStatus::EmptyDescription)
             {
-                gtk_style_context_add_class(gtk_widget_get_style_context(m_rowDescription), "error");
+                gtk_widget_add_css_class(m_rowDescription, "error");
                 adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowDescription), _("Description (Empty)"));
             }
             else if(status == TransactionCheckStatus::EmptyAmount)
             {
-                gtk_style_context_add_class(gtk_widget_get_style_context(m_rowAmount), "error");
+                gtk_widget_add_css_class(m_rowAmount, "error");
                 adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), _("Amount (Empty)"));
             }
             else if(status == TransactionCheckStatus::InvalidAmount)
             {
-                gtk_style_context_add_class(gtk_widget_get_style_context(m_rowAmount), "error");
+                gtk_widget_add_css_class(m_rowAmount, "error");
                 adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowAmount), _("Amount (Invalid)"));
             }
             return run();


### PR DESCRIPTION
# What
Removed deprecated functions

# Why
Since version 4.9.1 of GTK, the Gtk.StyleContext class has been deprecated in favor of the new styling functions in the Gtk.Widget class. See [GTK changelog](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/NEWS).

# How
The new method being used for adding a style is `gtk_widget_add_css_class`, and the one for removing a style is `gtk_widget_remove_css_class`. They have a much simpler syntax than the old Gtk.StyleContext. Each file using styling has been edited to use the new corresponding method.