### PR TITLE
Better handling of groups in .nmoney and .csv files

### DIFF
--- a/src/models/account.cpp
+++ b/src/models/account.cpp
@@ -383,7 +383,7 @@ int Account::importFromCSV(const std::string& path)
         {
             //Separate fields by ,
             std::vector<std::string> fields{ split(line, ",") };
-            if(fields.size() != 7)
+            if(fields.size() != 9)
             {
                 continue;
             }
@@ -455,21 +455,19 @@ int Account::importFromCSV(const std::string& path)
             }
             //Get Group Id
             int gid{ 0 };
-            if(gid != -1)
+            try
             {
-                try
-                {
-                    gid = stoui(fields[6]);
-                }
-                catch(...)
-                {
-                    continue;
-                }
-                if(getGroupById(gid) != std::nullopt)
-                {
-                    continue;
-                }
+                gid = stoui(fields[6]);
             }
+            catch(...)
+            {
+                continue;
+            }
+            //Get Group Name
+            const std::string& groupName{ fields[7] };
+            //Get Group Description
+            const std::string& groupDescription{ fields[8] };
+
             //Add Transaction
             Transaction transaction{ id };
             transaction.setDate(date);
@@ -479,9 +477,19 @@ int Account::importFromCSV(const std::string& path)
             transaction.setAmount(amount);
             transaction.setGroupId(gid);
             addTransaction(transaction);
+
+            //Add Group if needed
+            if (getGroupById(gid) == std::nullopt && gid != -1) {
+                Group group{ (unsigned int) gid };
+                group.setName(groupName);
+                group.setDescription(groupDescription);
+                addGroup(group);
+            }
+
             imported++;
         }
     }
+    updateGroupAmounts();
     return imported;
 }
 

--- a/src/models/account.cpp
+++ b/src/models/account.cpp
@@ -37,13 +37,13 @@ Account::Account(const std::string& path) : m_path{ path }, m_db{ std::make_shar
 {
     //Load Groups
     m_db->exec("CREATE TABLE IF NOT EXISTS groups (id INTEGER PRIMARY KEY, name TEXT, description TEXT, balance TEXT)");
-    SQLite::Statement qryGetAllGroups{ *m_db, "SELECT * FROM groups" };
+    SQLite::Statement qryGetAllGroups{ *m_db, "SELECT g.*, CAST(COALESCE(SUM(IIF(t.type=1, -t.amount, t.amount)), 0) AS TEXT) FROM groups g LEFT JOIN transactions t ON t.gid = g.id GROUP BY g.id;" };
     while(qryGetAllGroups.executeStep())
     {
         Group group{ (unsigned int)qryGetAllGroups.getColumn(0).getInt() };
         group.setName(qryGetAllGroups.getColumn(1).getString());
         group.setDescription(qryGetAllGroups.getColumn(2).getString());
-        group.setBalance(boost::multiprecision::cpp_dec_float_50(qryGetAllGroups.getColumn(3).getString()));
+        group.setBalance(boost::multiprecision::cpp_dec_float_50(qryGetAllGroups.getColumn(4).getString()));
         m_groups.insert({ group.getId(), group });
     }
     //Load Transactions

--- a/src/models/account.cpp
+++ b/src/models/account.cpp
@@ -350,7 +350,7 @@ bool Account::exportAsCSV(const std::string& path)
     std::ofstream file{ path };
     if(file.is_open())
     {
-        file << "ID,Date,Description,Type,RepeatInterval,Amount,Group\n";
+        file << "ID,Date,Description,Type,RepeatInterval,Amount,Group,GroupName,GroupDescription\n";
         for(const std::pair<const unsigned int, Transaction>& pair : m_transactions)
         {
             file << pair.second.getId() << ",";
@@ -359,7 +359,13 @@ bool Account::exportAsCSV(const std::string& path)
             file << static_cast<int>(pair.second.getType()) << ",";
             file << static_cast<int>(pair.second.getRepeatInterval()) << ",";
             file << pair.second.getAmount() << ",";
-            file << pair.second.getGroupId() << "\n";
+            file << pair.second.getGroupId() << ",";
+            if (pair.second.getGroupId() != -1) {
+                file << m_groups.at(pair.second.getGroupId()).getName() << ",";
+                file << m_groups.at(pair.second.getGroupId()).getDescription() << "\n";
+            } else {
+                file << ",\n";
+            }
         }
         return true;
     }

--- a/src/models/account.cpp
+++ b/src/models/account.cpp
@@ -37,12 +37,12 @@ Account::Account(const std::string& path) : m_path{ path }, m_db{ std::make_shar
 {
     //Load Groups
     m_db->exec("CREATE TABLE IF NOT EXISTS groups (id INTEGER PRIMARY KEY, name TEXT, description TEXT)");
-    SQLite::Statement qryGetAllGroups{ *m_db, "SELECT g.*, CAST(COALESCE(SUM(IIF(t.type=1, -t.amount, t.amount)), 0) AS TEXT) FROM groups g LEFT JOIN transactions t ON t.gid = g.id GROUP BY g.id;" };
     try
     {
         m_db->exec("ALTER TABLE groups DROP COLUMN balance");
     }
     catch(...) { }
+    SQLite::Statement qryGetAllGroups{ *m_db, "SELECT g.*, CAST(COALESCE(SUM(IIF(t.type=1, -t.amount, t.amount)), 0) AS TEXT) FROM groups g LEFT JOIN transactions t ON t.gid = g.id GROUP BY g.id;" };
     while(qryGetAllGroups.executeStep())
     {
         Group group{ (unsigned int)qryGetAllGroups.getColumn(0).getInt() };

--- a/src/models/account.cpp
+++ b/src/models/account.cpp
@@ -37,11 +37,6 @@ Account::Account(const std::string& path) : m_path{ path }, m_db{ std::make_shar
 {
     //Load Groups
     m_db->exec("CREATE TABLE IF NOT EXISTS groups (id INTEGER PRIMARY KEY, name TEXT, description TEXT)");
-    try
-    {
-        m_db->exec("ALTER TABLE groups DROP COLUMN balance");
-    }
-    catch(...) { }
     SQLite::Statement qryGetAllGroups{ *m_db, "SELECT g.*, CAST(COALESCE(SUM(IIF(t.type=1, -t.amount, t.amount)), 0) AS TEXT) FROM groups g LEFT JOIN transactions t ON t.gid = g.id GROUP BY g.id;" };
     while(qryGetAllGroups.executeStep())
     {

--- a/src/models/account.cpp
+++ b/src/models/account.cpp
@@ -355,7 +355,8 @@ bool Account::exportAsCSV(const std::string& path)
             file << static_cast<int>(pair.second.getRepeatInterval()) << ",";
             file << pair.second.getAmount() << ",";
             file << pair.second.getGroupId() << ",";
-            if (pair.second.getGroupId() != -1) {
+            if (pair.second.getGroupId() != -1)
+            {
                 file << m_groups.at(pair.second.getGroupId()).getName() << ",";
                 file << m_groups.at(pair.second.getGroupId()).getDescription() << "\n";
             } else {
@@ -474,7 +475,8 @@ int Account::importFromCSV(const std::string& path)
             addTransaction(transaction);
 
             //Add Group if needed
-            if (getGroupById(gid) == std::nullopt && gid != -1) {
+            if (getGroupById(gid) == std::nullopt && gid != -1)
+            {
                 Group group{ (unsigned int) gid };
                 group.setName(groupName);
                 group.setDescription(groupDescription);
@@ -494,7 +496,6 @@ void Account::updateGroupAmounts()
     SQLite::Statement qryGetGroupsBalance{ *m_db, "SELECT g.id, CAST(COALESCE(SUM(IIF(t.type=1, -t.amount, t.amount)), 0) AS TEXT) FROM transactions t RIGHT JOIN groups g on g.id = t.gid GROUP BY g.id;" };
     while(qryGetGroupsBalance.executeStep())
     {
-        int index{ qryGetGroupsBalance.getColumn(0).getInt() };
-        m_groups[index].setBalance(boost::multiprecision::cpp_dec_float_50(qryGetGroupsBalance.getColumn(1).getString()));
+        m_groups.at(qryGetGroupsBalance.getColumn(0).getInt()).setBalance(boost::multiprecision::cpp_dec_float_50(qryGetGroupsBalance.getColumn(1).getString()));
     }
 }


### PR DESCRIPTION
# What
This pull request focuses on a better integration of groups in the nmoney database files and csv files.

# Why
What motivated the change in the nmoney file is that the balance was hardcoded, while it simply is a sum of all the transactions' amounts, which SQL could easily handle. There was clearly a kind of indirect data duplication, which is now removed. As for the CSV file, it did not allow to export groups so far.

# How
The new `groups` table in nmoney files no longer has a balance column. Instead, a SQL request is made to do the calculation of the balance, as seen in the new `Account::updateGroupAmounts` method. The column will be automatically deleted on old files to match with the new file version.

In the CSV file, each transaction comes with its gid, group name and group description, so that the group can be added if it does not exist. This means that a group will surely appear more than once, but this limitation is due to CSV files being having only a single table, not two tables as in SQL.

@fsobolev 