### PR TITLE
Corrected shortcut in Hindi translation

### DIFF
--- a/po/hi.po
+++ b/po/hi.po
@@ -234,7 +234,7 @@ msgstr "नया"
 
 #: src/ui/views/mainwindow.cpp:44
 msgid "New Account (Ctrl+N)"
-msgstr "नया खाता (Ctrl+G)"
+msgstr "नया खाता (Ctrl+N)"
 
 #: src/ui/views/mainwindow.cpp:50
 msgid "Open Account (Ctrl+O)"


### PR DESCRIPTION
Somehow in previous translation updates, "New Group" changed to "New Account" and due to fuzzy function, it remained some part of it, and i forgot to verify it and it caused me to keep it something like "New Account (Ctrl+G)" which is a shortcut mismatch. Just this one corrects it.