### PR TITLE
Localised desktop file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,9 +14,19 @@ subdir('src')
 subdir('po')
 
 executable('org.nickvision.money', sources, dependencies: [threads, adwaita, jsoncpp, dl, sqlitecpp, boost], install: true)
+
+# Desktop file
+po_dir = join_paths(meson.project_source_root(), 'po')
+desktop_file = i18n.merge_file(
+        input: join_paths(meson.project_source_root(), 'org.nickvision.money.desktop'),
+       output: 'org.nickvision.money.desktop',
+         type: 'desktop',
+       po_dir: po_dir,
+      install: true,
+  install_dir: 'share/applications')
+
 install_data(resources, install_dir: 'share/icons/hicolor/scalable/apps')
 install_data(resources_symbolic, install_dir: 'share/icons/hicolor/symbolic/apps')
 install_data(resources_actions, install_dir: 'share/icons/hicolor/scalable/actions')
-install_data('org.nickvision.money.desktop', install_dir: 'share/applications')
 install_data('org.nickvision.money.metainfo.xml', install_dir: 'share/metainfo')
 gnome.post_install(gtk_update_icon_cache: true, update_desktop_database: true)

--- a/org.nickvision.money.desktop
+++ b/org.nickvision.money.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Version=1.0
+# Do not translate the app name, though you may transliterate into different script
 Name=Money
 Comment=A personal finance manager
 Exec=org.nickvision.money

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -12,3 +12,4 @@ src/ui/views/mainwindow.cpp
 src/ui/views/preferencesdialog.cpp
 src/ui/views/shortcutsdialog.cpp
 src/ui/views/transactiondialog.cpp
+org.nickvision.money.desktop


### PR DESCRIPTION
All the GNOME apps make use of localised desktop file, i.e. the descriptions of app are localised in .desktop file. I implemented the localisation of desktop file here. Though I did not update the po files, i.e. I did not execute `meson compile org.nickvision.money-update-po`, so no new translation strings are added in exising po files. I did this so that merging does not create any conflicts with any existing translation updates pull request. After merging of this branch, someone may update all po files by `meson compile org.nickvision.money` and everyone may update the translation files.

I have tested this locally, localised description of 'A person finance manager' is shown successfully in the app drawer.

Also, regarding gnome guidelines, the name of app should not change, like "Money" should remain Money, but it may be transliterated (not translated) so that knowers of other script can read it. But, app description is translated.