### PR TITLE
Support for translating plurals

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -7,13 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.money\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-17 10:33+0100\n"
-"PO-Revision-Date: 2022-11-06 10:02+0100\n"
+"POT-Creation-Date: 2022-11-18 22:06+0100\n"
+"PO-Revision-Date: 2022-11-18 22:09+0100\n"
 "Last-Translator: Enzo MAROS <enzo.maros@gmail.com>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
 
 #: src/controllers/accountviewcontroller.cpp:63
 msgid "Exported account to CSV successfully."
@@ -25,8 +26,10 @@ msgstr "Impossible d'exporter le compte au format CSV"
 
 #: src/controllers/accountviewcontroller.cpp:78
 #, c-format
-msgid "Imported %d transactions from CSV."
-msgstr "%d transaction importées depuis le CSV"
+msgid "Imported %d transaction from CSV."
+msgid_plural "Imported %d transactions from CSV."
+msgstr[0] "%d transaction importée depuis le CSV"
+msgstr[1] "%d transaction importées depuis le CSV"
 
 #: src/controllers/mainwindowcontroller.cpp:49
 msgctxt "Night"
@@ -173,16 +176,16 @@ msgstr "Nouvelle transaction (Ctrl+Maj+N)"
 msgid "Transactions"
 msgstr "Transactions"
 
-#: src/ui/views/accountview.cpp:183 src/ui/views/mainwindow.cpp:243
+#: src/ui/views/accountview.cpp:183 src/ui/views/mainwindow.cpp:251
 msgid "_Save"
 msgstr "_Enregistrer"
 
 #: src/ui/views/accountview.cpp:183 src/ui/views/accountview.cpp:207
-#: src/ui/views/mainwindow.cpp:243 src/ui/views/mainwindow.cpp:279
+#: src/ui/views/mainwindow.cpp:251 src/ui/views/mainwindow.cpp:287
 msgid "_Cancel"
 msgstr "_Annuler"
 
-#: src/ui/views/accountview.cpp:207 src/ui/views/mainwindow.cpp:279
+#: src/ui/views/accountview.cpp:207 src/ui/views/mainwindow.cpp:287
 msgid "_Open"
 msgstr "_Ouvrir"
 
@@ -285,14 +288,16 @@ msgstr "Menu principal"
 msgid "New Account"
 msgstr "Nouveau compte"
 
-#: src/ui/views/mainwindow.cpp:111 src/ui/views/mainwindow.cpp:243
-#: src/ui/views/mainwindow.cpp:279 src/ui/views/shortcutsdialog.cpp:97
+#: src/ui/views/mainwindow.cpp:111 src/ui/views/mainwindow.cpp:251
+#: src/ui/views/mainwindow.cpp:287 src/ui/views/shortcutsdialog.cpp:97
 msgid "Open Account"
 msgstr "Ouvrir un compte"
 
 #: src/ui/views/mainwindow.cpp:115
 msgid "You may also drag in a file from your file browser to open."
-msgstr "Vous pouvez aussi glisser-déposer un fichier depuis votre explorateur de fichier."
+msgstr ""
+"Vous pouvez aussi glisser-déposer un fichier depuis votre explorateur de "
+"fichier."
 
 #: src/ui/views/mainwindow.cpp:126
 msgid "Recent Accounts"
@@ -302,11 +307,11 @@ msgstr "Compte récents"
 msgid "Open or create an account to get started."
 msgstr "Ouvrez ou créez un compte pour commencer"
 
-#: src/ui/views/mainwindow.cpp:246 src/ui/views/mainwindow.cpp:282
+#: src/ui/views/mainwindow.cpp:254 src/ui/views/mainwindow.cpp:290
 msgid "Money Account (*.nmoney)"
 msgstr "Compte Money (*.nmoney)"
 
-#: src/ui/views/mainwindow.cpp:259
+#: src/ui/views/mainwindow.cpp:267
 msgid "Unable to override an opened account."
 msgstr "Impossible de remplacer un compte ouvert."
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.money\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-15 23:19+0300\n"
+"POT-Creation-Date: 2022-11-19 01:00+0100\n"
 "PO-Revision-Date: 2022-11-16 16:24+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
@@ -15,8 +15,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.0\n"
 
 #: src/controllers/accountviewcontroller.cpp:63
@@ -28,9 +28,12 @@ msgid "Unable to export account as CSV."
 msgstr "Nije moguće izvesti račun kao CSV datoteku."
 
 #: src/controllers/accountviewcontroller.cpp:78
-#, c-format
-msgid "Imported %d transactions from CSV."
-msgstr "Uvezene transakcije iz CSV datoteke: %d."
+#, fuzzy, c-format
+msgid "Imported %d transaction from CSV."
+msgid_plural "Imported %d transactions from CSV."
+msgstr[0] "Uvezene transakcije iz CSV datoteke: %d."
+msgstr[1] "Uvezene transakcije iz CSV datoteke: %d."
+msgstr[2] "Uvezene transakcije iz CSV datoteke: %d."
 
 #: src/controllers/mainwindowcontroller.cpp:49
 msgctxt "Night"
@@ -177,16 +180,16 @@ msgstr "Nova transakcija (Ctrl+Shift+N)"
 msgid "Transactions"
 msgstr "Transakcije"
 
-#: src/ui/views/accountview.cpp:183 src/ui/views/mainwindow.cpp:229
+#: src/ui/views/accountview.cpp:183 src/ui/views/mainwindow.cpp:251
 msgid "_Save"
 msgstr "_Spremi"
 
 #: src/ui/views/accountview.cpp:183 src/ui/views/accountview.cpp:207
-#: src/ui/views/mainwindow.cpp:229 src/ui/views/mainwindow.cpp:265
+#: src/ui/views/mainwindow.cpp:251 src/ui/views/mainwindow.cpp:287
 msgid "_Cancel"
 msgstr "O_dustani"
 
-#: src/ui/views/accountview.cpp:207 src/ui/views/mainwindow.cpp:265
+#: src/ui/views/accountview.cpp:207 src/ui/views/mainwindow.cpp:287
 msgid "_Open"
 msgstr "_Otvori"
 
@@ -226,24 +229,24 @@ msgstr ""
 msgid "Group"
 msgstr "Grupa"
 
-#: src/ui/views/groupdialog.cpp:21 src/ui/views/groupdialog.cpp:59
+#: src/ui/views/groupdialog.cpp:21 src/ui/views/groupdialog.cpp:61
 msgid "Name"
 msgstr "Ime"
 
-#: src/ui/views/groupdialog.cpp:27 src/ui/views/groupdialog.cpp:61
-#: src/ui/views/transactiondialog.cpp:45 src/ui/views/transactiondialog.cpp:109
+#: src/ui/views/groupdialog.cpp:27 src/ui/views/groupdialog.cpp:63
+#: src/ui/views/transactiondialog.cpp:45 src/ui/views/transactiondialog.cpp:111
 msgid "Description"
 msgstr "Opis"
 
-#: src/ui/views/groupdialog.cpp:66
+#: src/ui/views/groupdialog.cpp:68
 msgid "Name (Empty)"
 msgstr "Ime (prazno)"
 
-#: src/ui/views/groupdialog.cpp:71 src/ui/views/transactiondialog.cpp:116
+#: src/ui/views/groupdialog.cpp:73 src/ui/views/transactiondialog.cpp:118
 msgid "Description (Empty)"
 msgstr "Opis (prazan)"
 
-#: src/ui/views/groupdialog.cpp:76
+#: src/ui/views/groupdialog.cpp:78
 msgid "Name (Exists)"
 msgstr "Ime (postoji)"
 
@@ -289,8 +292,8 @@ msgstr "Glavni izbornik"
 msgid "New Account"
 msgstr "Novi račun"
 
-#: src/ui/views/mainwindow.cpp:111 src/ui/views/mainwindow.cpp:229
-#: src/ui/views/mainwindow.cpp:265 src/ui/views/shortcutsdialog.cpp:97
+#: src/ui/views/mainwindow.cpp:111 src/ui/views/mainwindow.cpp:251
+#: src/ui/views/mainwindow.cpp:287 src/ui/views/shortcutsdialog.cpp:97
 msgid "Open Account"
 msgstr "Otvori račun"
 
@@ -306,11 +309,11 @@ msgstr "Nedavni računi"
 msgid "Open or create an account to get started."
 msgstr "Otvori ili stvori jedan račun."
 
-#: src/ui/views/mainwindow.cpp:232 src/ui/views/mainwindow.cpp:268
+#: src/ui/views/mainwindow.cpp:254 src/ui/views/mainwindow.cpp:290
 msgid "Money Account (*.nmoney)"
 msgstr "Money račun (*.nmoney)"
 
-#: src/ui/views/mainwindow.cpp:245
+#: src/ui/views/mainwindow.cpp:267
 msgid "Unable to override an opened account."
 msgstr "Nije moguće prepisati istoimen otvoreni račun."
 
@@ -397,15 +400,15 @@ msgstr "Rashod"
 msgid "Repeat Interval"
 msgstr "Interval ponavljanja"
 
-#: src/ui/views/transactiondialog.cpp:72 src/ui/views/transactiondialog.cpp:111
+#: src/ui/views/transactiondialog.cpp:72 src/ui/views/transactiondialog.cpp:113
 msgid "Amount"
 msgstr "Iznos"
 
-#: src/ui/views/transactiondialog.cpp:121
+#: src/ui/views/transactiondialog.cpp:123
 msgid "Amount (Empty)"
 msgstr "Iznos (prazan)"
 
-#: src/ui/views/transactiondialog.cpp:126
+#: src/ui/views/transactiondialog.cpp:128
 msgid "Amount (Invalid)"
 msgstr "Iznos (neispravan)"
 

--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -75,7 +75,7 @@ void AccountViewController::importFromCSV(std::string& path)
     {
         m_accountInfoChangedCallback();
     }
-    m_sendToastCallback(StringHelpers::format(_("Imported %d transactions from CSV."), imported));
+    m_sendToastCallback(StringHelpers::format(ngettext("Imported %d transaction from CSV.", "Imported %d transactions from CSV.", imported), imported));
 }
 
 void AccountViewController::addGroup(const Group& group)


### PR DESCRIPTION
# What
Support for translating plurals, and updated french translation to that particular behavior.

# Why
As explained in #48, when working with numbers, languages don't behave the same way. While English only has two forms, singular and plural, other languages like Croatian may have up to two plurals depending on the amount before. It is thus important for each language to be able to translate to the right word thanks by taking into account the number it is preceded by.

# How
The only string that must be changed is when importing CSV files, in **src/controllers/accountviewcontroller.cpp**

I used the `ngettext` function which takes as arguments the English singular form, the plural form, and the number actually written by `%d`,. Gettext will then regenerate each PO file, find how many different plural forms have to be created thanks to the `Plural-Form` header, and write as much entry as needed. To find the correct plural form to use, see [Gettext official documentation](https://www.gnu.org/software/gettext/manual/gettext.html#index-specifying-plural-form-in-a-PO-file).

*For this change to apply to all languages, PO files have to be regenerated by meson. It is preferable that each translator adds his plural form header first and regenerates his own file rather than regenerating them all at once right now.*