### PR TITLE
Fix decimal zeros

### DIFF
--- a/src/helpers/moneyhelpers.cpp
+++ b/src/helpers/moneyhelpers.cpp
@@ -20,7 +20,7 @@ std::string MoneyHelpers::boostMoneyToLocaleString(boost::multiprecision::cpp_de
     {
         builder << (isLocaleDotDecimalSeperated(locale) ? ".00" : ",00");
     }
-    else if(std::fmod(decimal, 10.0) == 0)
+    else if(std::fmod(decimal, 10.0) < 0.001)
     {
         builder << "0";
     }


### PR DESCRIPTION
Fix #97 
The problem was that `std::fmod` returns veeeeery small number, but not 0.