### PR TITLE
Support for QIF and OFX file types

### DIFF
--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -135,7 +135,8 @@ void AccountViewController::importFromFile(std::string& path)
     {
         m_sendToastCallback("Unsupported file type");
     }
-    else {
+    else
+    {
         m_sendToastCallback(StringHelpers::format(ngettext("Imported %d transaction from file.", "Imported %d transactions from file.", imported), imported));
     }
 }

--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -116,9 +116,9 @@ void AccountViewController::exportAsCSV(std::string& path)
     }
 }
 
-void AccountViewController::importFromCSV(std::string& path)
+void AccountViewController::importFromFile(std::string& path)
 {
-    int imported{ m_account.importFromCSV(path) };
+    int imported{ m_account.importFromFile(path) };
     if(imported > 0)
     {
         for(const std::pair<const unsigned int, Group>& pair : m_account.getGroups())
@@ -130,7 +130,14 @@ void AccountViewController::importFromCSV(std::string& path)
         }
         m_accountInfoChangedCallback();
     }
-    m_sendToastCallback(StringHelpers::format(ngettext("Imported %d transaction from CSV.", "Imported %d transactions from CSV.", imported), imported));
+
+    if (imported == -1)
+    {
+        m_sendToastCallback("Unsupported file type");
+    }
+    else {
+        m_sendToastCallback(StringHelpers::format(ngettext("Imported %d transaction from file.", "Imported %d transactions from file.", imported), imported));
+    }
 }
 
 void AccountViewController::addGroup(const Group& group)

--- a/src/controllers/accountviewcontroller.hpp
+++ b/src/controllers/accountviewcontroller.hpp
@@ -123,9 +123,9 @@ namespace NickvisionMoney::Controllers
 		 */
 		void exportAsCSV(std::string& path);
 		/**
-		 * Import transactions from a CSV file
+		 * Import transactions from a file
 		 *
-		 * @param path The path to the csv file
+		 * @param path The path to the file
 		 */
 		void importFromFile(std::string& path);
 		/**

--- a/src/controllers/accountviewcontroller.hpp
+++ b/src/controllers/accountviewcontroller.hpp
@@ -127,7 +127,7 @@ namespace NickvisionMoney::Controllers
 		 *
 		 * @param path The path to the csv file
 		 */
-		void importFromCSV(std::string& path);
+		void importFromFile(std::string& path);
 		/**
 		 * Adds a new group to the account
 		 *

--- a/src/models/account.cpp
+++ b/src/models/account.cpp
@@ -386,6 +386,15 @@ bool Account::exportAsCSV(const std::string& path)
     return false;
 }
 
+int Account::importFromFile(const std::string& path) {
+    if (path.ends_with(".csv"))
+    {
+        return importFromCSV(path);
+    }
+
+    return -1;
+}
+
 int Account::importFromCSV(const std::string& path)
 {
     int imported{ 0 };

--- a/src/models/account.hpp
+++ b/src/models/account.hpp
@@ -159,6 +159,14 @@ namespace NickvisionMoney::Models
          */
         int importFromOFX(const std::string& path);
 
+        /**
+         * Imports transactions to the account from a QIF file
+         *
+         * @param path The path of the QIF file
+         * @returns The number of transactions imported
+         */
+        int importFromQIF(const std::string& path);
+
 	private:
 		std::string m_path;
         std::shared_ptr<SQLite::Database> m_db;

--- a/src/models/account.hpp
+++ b/src/models/account.hpp
@@ -151,6 +151,14 @@ namespace NickvisionMoney::Models
          */
         int importFromCSV(const std::string& path);
 
+        /**
+         * Imports transactions to the account from a OFX file
+         *
+         * @param path The path of the OFX file
+         * @returns The number of transactions imported
+         */
+        int importFromOFX(const std::string& path);
+
 	private:
 		std::string m_path;
         std::shared_ptr<SQLite::Database> m_db;

--- a/src/models/account.hpp
+++ b/src/models/account.hpp
@@ -135,6 +135,15 @@ namespace NickvisionMoney::Models
          */
         bool exportAsCSV(const std::string& path);
         /**
+         * Detects and calls the right function for the import depending on
+         * the file type
+         * 
+         * @param path The path of the file
+         * @returns The number of transactions imported, or -1 if the file format is unsupported
+         */
+        int importFromFile(const std::string& path);
+
+        /**
          * Imports transactions to the account from a CSV file
          *
          * @param path The path of the CSV file

--- a/src/ui/views/accountview.cpp
+++ b/src/ui/views/accountview.cpp
@@ -461,6 +461,12 @@ void AccountView::onImportFromFile()
     gtk_file_filter_add_pattern(filter, "*.ofx");
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(openFileDialog), filter);
     g_object_unref(filter);
+    // QIF support
+    filter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filter, "Quicken Format (*.qif)");
+    gtk_file_filter_add_pattern(filter, "*.qif");
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(openFileDialog), filter);
+    g_object_unref(filter);
     
     g_signal_connect(openFileDialog, "response", G_CALLBACK((void (*)(GtkNativeDialog*, gint, gpointer))([](GtkNativeDialog* dialog, gint response_id, gpointer data)
     {

--- a/src/ui/views/accountview.cpp
+++ b/src/ui/views/accountview.cpp
@@ -450,10 +450,18 @@ void AccountView::onImportFromFile()
     GtkFileChooserNative* openFileDialog{ gtk_file_chooser_native_new(_("Import from CSV"), m_parentWindow, GTK_FILE_CHOOSER_ACTION_OPEN, _("_Open"), _("_Cancel")) };
     gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(openFileDialog), true);
     GtkFileFilter* filter{ gtk_file_filter_new() };
+    // CSV support
     gtk_file_filter_set_name(filter, "CSV (*.csv)");
     gtk_file_filter_add_pattern(filter, "*.csv");
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(openFileDialog), filter);
     g_object_unref(filter);
+    // OFX support
+    filter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filter, "Open Financial Exchange (*.ofx)");
+    gtk_file_filter_add_pattern(filter, "*.ofx");
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(openFileDialog), filter);
+    g_object_unref(filter);
+    
     g_signal_connect(openFileDialog, "response", G_CALLBACK((void (*)(GtkNativeDialog*, gint, gpointer))([](GtkNativeDialog* dialog, gint response_id, gpointer data)
     {
         if(response_id == GTK_RESPONSE_ACCEPT)

--- a/src/ui/views/accountview.cpp
+++ b/src/ui/views/accountview.cpp
@@ -70,7 +70,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, Gtk
     gtk_menu_button_set_child(GTK_MENU_BUTTON(m_btnMenuAccountActions), btnMenuAccountActionsContent);
     GMenu* menuActionsCSV{ g_menu_new() };
     g_menu_append(menuActionsCSV, _("Export as CSV"), "account.exportAsCSV");
-    g_menu_append(menuActionsCSV, _("Import from CSV"), "account.importFromCSV");
+    g_menu_append(menuActionsCSV, _("Import from file"), "account.importFromFile");
     GMenu* menuActions{ g_menu_new() };
     g_menu_append(menuActions, _("Transfer Money"), "account.transferMoney");
     g_menu_append_section(menuActions, nullptr, G_MENU_MODEL(menuActionsCSV));
@@ -277,9 +277,9 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, Gtk
     g_signal_connect(m_actExportAsCSV, "activate", G_CALLBACK((void (*)(GSimpleAction*, GVariant*, gpointer))[](GSimpleAction*, GVariant*, gpointer data) { reinterpret_cast<AccountView*>(data)->onExportAsCSV(); }), this);
     g_action_map_add_action(G_ACTION_MAP(m_actionMap), G_ACTION(m_actExportAsCSV));
     //Import from CSV Action
-    m_actImportFromCSV = g_simple_action_new("importFromCSV", nullptr);
-    g_signal_connect(m_actImportFromCSV, "activate", G_CALLBACK((void (*)(GSimpleAction*, GVariant*, gpointer))[](GSimpleAction*, GVariant*, gpointer data) { reinterpret_cast<AccountView*>(data)->onImportFromCSV(); }), this);
-    g_action_map_add_action(G_ACTION_MAP(m_actionMap), G_ACTION(m_actImportFromCSV));
+    m_actImportFromFile = g_simple_action_new("importFromFile", nullptr);
+    g_signal_connect(m_actImportFromFile, "activate", G_CALLBACK((void (*)(GSimpleAction*, GVariant*, gpointer))[](GSimpleAction*, GVariant*, gpointer data) { reinterpret_cast<AccountView*>(data)->onImportFromFile(); }), this);
+    g_action_map_add_action(G_ACTION_MAP(m_actionMap), G_ACTION(m_actImportFromFile));
     //New Group Action
     m_actNewGroup = g_simple_action_new("newGroup", nullptr);
     g_signal_connect(m_actNewGroup, "activate", G_CALLBACK((void (*)(GSimpleAction*, GVariant*, gpointer))[](GSimpleAction*, GVariant*, gpointer data) { reinterpret_cast<AccountView*>(data)->onNewGroup(); }), this);
@@ -293,7 +293,7 @@ AccountView::AccountView(GtkWindow* parentWindow, AdwTabView* parentTabView, Gtk
     gtk_shortcut_controller_set_scope(GTK_SHORTCUT_CONTROLLER(m_shortcutController), GTK_SHORTCUT_SCOPE_MANAGED);
     gtk_shortcut_controller_add_shortcut(GTK_SHORTCUT_CONTROLLER(m_shortcutController), gtk_shortcut_new(gtk_shortcut_trigger_parse_string("<Ctrl>T"), gtk_named_action_new("account.transferMoney")));
     gtk_shortcut_controller_add_shortcut(GTK_SHORTCUT_CONTROLLER(m_shortcutController), gtk_shortcut_new(gtk_shortcut_trigger_parse_string("<Ctrl>E"), gtk_named_action_new("account.exportAsCSV")));
-    gtk_shortcut_controller_add_shortcut(GTK_SHORTCUT_CONTROLLER(m_shortcutController), gtk_shortcut_new(gtk_shortcut_trigger_parse_string("<Ctrl>I"), gtk_named_action_new("account.importFromCSV")));
+    gtk_shortcut_controller_add_shortcut(GTK_SHORTCUT_CONTROLLER(m_shortcutController), gtk_shortcut_new(gtk_shortcut_trigger_parse_string("<Ctrl>I"), gtk_named_action_new("account.importFromFile")));
     gtk_shortcut_controller_add_shortcut(GTK_SHORTCUT_CONTROLLER(m_shortcutController), gtk_shortcut_new(gtk_shortcut_trigger_parse_string("<Ctrl>G"), gtk_named_action_new("account.newGroup")));
     gtk_shortcut_controller_add_shortcut(GTK_SHORTCUT_CONTROLLER(m_shortcutController), gtk_shortcut_new(gtk_shortcut_trigger_parse_string("<Ctrl><Shift>N"), gtk_named_action_new("account.newTransaction")));
     gtk_widget_add_controller(m_flap, m_shortcutController);
@@ -445,7 +445,7 @@ void AccountView::onExportAsCSV()
     gtk_native_dialog_show(GTK_NATIVE_DIALOG(saveFileDialog));
 }
 
-void AccountView::onImportFromCSV()
+void AccountView::onImportFromFile()
 {
     GtkFileChooserNative* openFileDialog{ gtk_file_chooser_native_new(_("Import from CSV"), m_parentWindow, GTK_FILE_CHOOSER_ACTION_OPEN, _("_Open"), _("_Cancel")) };
     gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(openFileDialog), true);
@@ -461,7 +461,7 @@ void AccountView::onImportFromCSV()
             AccountView* accountView{ reinterpret_cast<AccountView*>(data) };
             GFile* file{ gtk_file_chooser_get_file(GTK_FILE_CHOOSER(dialog)) };
             std::string path{ g_file_get_path(file) };
-            ProgressDialog progressDialog{ accountView->m_parentWindow, "Importing from CSV...", [accountView, &path]() { accountView->m_controller->importFromCSV(path); } };
+            ProgressDialog progressDialog{ accountView->m_parentWindow, "Importing from file...", [accountView, &path]() { accountView->m_controller->importFromFile(path); } };
             progressDialog.run();
             g_object_unref(file);
         }

--- a/src/ui/views/accountview.hpp
+++ b/src/ui/views/accountview.hpp
@@ -74,7 +74,7 @@ namespace NickvisionMoney::UI::Views
 		GSimpleActionGroup* m_actionMap{ nullptr };
 		GSimpleAction* m_actTransferMoney{ nullptr };
 		GSimpleAction* m_actExportAsCSV{ nullptr };
-		GSimpleAction* m_actImportFromCSV{ nullptr };
+		GSimpleAction* m_actImportFromFile{ nullptr };
 		GSimpleAction* m_actNewGroup{ nullptr };
 		GSimpleAction* m_actNewTransaction{ nullptr };
 		GtkEventController* m_shortcutController{ nullptr };
@@ -96,7 +96,7 @@ namespace NickvisionMoney::UI::Views
 		/**
 		 * Occurs when the import from csv menu item is clicked
 		 */
-		void onImportFromCSV();
+		void onImportFromFile();
 		/**
 		 * Occurs when the reset overview filter is clicked
 		 */


### PR DESCRIPTION
# What
Support for the Quicken Format (**.qif** files) and Open Financial Exchange (**.ofx** files)

# Why
Money misses the ability to import from the outside, as the CSV files are so far only available for the app itself. The two formats **QIF** and **OFX** are two of the international formats used by other apps to manipulate financial data. My own bank allows me to export my accounts to any of those types, so I can now use Money with my actual daily transactions.

# How
The UI was changed to allow users to import from the file type they want (CSV format still being the first one), in the `AccountView`. The `Account` model is now responsible for detecting the right type of the file and calls the appropriate function. Two new import methods have thus been added to the model: `importFromOFX` and `importFromQIF`.

Here are the specs for the two file types:
- [QIF Format](https://web.archive.org/web/20100222214101/http://web.intuit.com/support/quicken/docs/d_qif.html)
- [OFX Format](https://financialdataexchange.org/common/Uploaded%20files/OFX%20files/OFX%20Banking%20Specification%20v2.3.pdf)

_I'm open to any change that must be added, as it is my first real C++ addition to the project. Any coding advice is welcome. I'm also planning on updating all PO files and translating in French once the code is good for merging_