### PR TITLE
Default Colors Settings

### DIFF
--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -192,12 +192,12 @@ void AccountViewController::deleteTransaction(unsigned int id)
 
 TransactionDialogController AccountViewController::createTransactionDialogController() const
 {
-    return { m_account.getNextAvailableTransactionId(), m_account.getGroups(), m_configuration.getLocale(), m_configuration.getTransactionDefaultColor() };
+    return { m_account.getNextAvailableTransactionId(), m_account.getGroups(), m_configuration };
 }
 
 TransactionDialogController AccountViewController::createTransactionDialogController(unsigned int id) const
 {
-    return { m_account.getTransactionById(id).value(), m_account.getGroups(), m_configuration.getLocale(), m_configuration.getTransactionDefaultColor() };
+    return { m_account.getTransactionById(id).value(), m_account.getGroups(), m_configuration };
 }
 
 bool AccountViewController::getSortFirstToLast() const

--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -192,12 +192,12 @@ void AccountViewController::deleteTransaction(unsigned int id)
 
 TransactionDialogController AccountViewController::createTransactionDialogController() const
 {
-    return { m_account.getNextAvailableTransactionId(), m_account.getGroups(), m_configuration.getLocale() };
+    return { m_account.getNextAvailableTransactionId(), m_account.getGroups(), m_configuration.getLocale(), m_configuration };
 }
 
 TransactionDialogController AccountViewController::createTransactionDialogController(unsigned int id) const
 {
-    return { m_account.getTransactionById(id).value(), m_account.getGroups(), m_configuration.getLocale() };
+    return { m_account.getTransactionById(id).value(), m_account.getGroups(), m_configuration.getLocale(), m_configuration };
 }
 
 bool AccountViewController::getSortFirstToLast() const

--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -192,12 +192,12 @@ void AccountViewController::deleteTransaction(unsigned int id)
 
 TransactionDialogController AccountViewController::createTransactionDialogController() const
 {
-    return { m_account.getNextAvailableTransactionId(), m_account.getGroups(), m_configuration.getLocale(), m_configuration };
+    return { m_account.getNextAvailableTransactionId(), m_account.getGroups(), m_configuration.getLocale(), m_configuration.getTransactionDefaultColor() };
 }
 
 TransactionDialogController AccountViewController::createTransactionDialogController(unsigned int id) const
 {
-    return { m_account.getTransactionById(id).value(), m_account.getGroups(), m_configuration.getLocale(), m_configuration };
+    return { m_account.getTransactionById(id).value(), m_account.getGroups(), m_configuration.getLocale(), m_configuration.getTransactionDefaultColor() };
 }
 
 bool AccountViewController::getSortFirstToLast() const

--- a/src/controllers/accountviewcontroller.cpp
+++ b/src/controllers/accountviewcontroller.cpp
@@ -85,6 +85,7 @@ void AccountViewController::sendTransfer(const Transfer& transfer)
     transaction.setDescription(StringHelpers::format(_("Transfer To %s"), std::filesystem::path(transfer.getDestAccountPath()).stem().string().c_str()));
     transaction.setType(TransactionType::Expense);
     transaction.setAmount(transfer.getAmount());
+    transaction.setRGBA(m_configuration.getTransferDefaultColor());
     m_account.addTransaction(transaction);
     m_accountInfoChangedCallback();
     m_receiveTransferCallback(transfer);
@@ -96,6 +97,7 @@ void AccountViewController::receiveTransfer(const Transfer& transfer)
     transaction.setDescription(StringHelpers::format(_("Transfer From %s"), std::filesystem::path(transfer.getSourceAccountPath()).stem().string().c_str()));
     transaction.setType(TransactionType::Income);
     transaction.setAmount(transfer.getAmount());
+    transaction.setRGBA(m_configuration.getTransferDefaultColor());
     m_account.addTransaction(transaction);
     m_accountInfoChangedCallback();
 }

--- a/src/controllers/preferencesdialogcontroller.cpp
+++ b/src/controllers/preferencesdialogcontroller.cpp
@@ -18,6 +18,26 @@ void PreferencesDialogController::setTheme(int theme)
     m_configuration.setTheme(static_cast<Theme>(theme));
 }
 
+const std::string& PreferencesDialogController::getTransactionDefaultColor() const
+{
+    return m_configuration.getTransactionDefaultColor();
+}
+
+void PreferencesDialogController::setTransactionDefaultColor(std::string color)
+{
+    m_configuration.setTransactionDefaultColor(color);
+}
+
+const std::string& PreferencesDialogController::getTransferDefaultColor() const
+{
+    return m_configuration.getTransferDefaultColor();
+}
+
+void PreferencesDialogController::setTransferDefaultColor(std::string color)
+{
+    m_configuration.setTransferDefaultColor(color);
+}
+
 void PreferencesDialogController::saveConfiguration() const
 {
     m_configuration.save();

--- a/src/controllers/preferencesdialogcontroller.hpp
+++ b/src/controllers/preferencesdialogcontroller.hpp
@@ -29,6 +29,30 @@ namespace NickvisionMoney::Controllers
 		 */
 		void setTheme(int theme);
 		/**
+		 * Gets transaction default color
+		 *
+		 * @returns Transaction default color (RGB string)
+		 */
+		const std::string& getTransactionDefaultColor() const;
+		/**
+		 * Sets transaction default color
+		 *
+		 * @param color New transaction default color (RGB string)
+		 */
+		void setTransactionDefaultColor(std::string color);
+		/**
+		 * Gets transfer default color
+		 *
+		 * @returns Transfer default color (RGB string)
+		 */
+		const std::string& getTransferDefaultColor() const;
+		/**
+		 * Sets transfer default color
+		 *
+		 * @param color New transfer default color (RGB string)
+		 */
+		void setTransferDefaultColor(std::string color);
+		/**
 		 * Saves the configuration file
 		 */
 		void saveConfiguration() const;

--- a/src/controllers/transactiondialogcontroller.cpp
+++ b/src/controllers/transactiondialogcontroller.cpp
@@ -7,7 +7,7 @@ using namespace NickvisionMoney::Controllers;
 using namespace NickvisionMoney::Helpers;
 using namespace NickvisionMoney::Models;
 
-TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, const std::locale& locale, const std::string& defaultColor) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ newId }, m_groups{ groups }, m_defaultColor{ defaultColor }
+TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, Configuration& configuration) : m_response{ "cancel" }, m_transaction{ newId }, m_groups{ groups }, m_configuration{ configuration }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {
@@ -17,7 +17,7 @@ TransactionDialogController::TransactionDialogController(unsigned int newId, con
     m_groupNames.insert(m_groupNames.begin(), _("None"));
 }
 
-TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, const std::locale& locale, const std::string& defaultColor) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ transaction }, m_groups{ groups }, m_defaultColor{ defaultColor }
+TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, Configuration& configuration) : m_response{ "cancel" }, m_transaction{ transaction }, m_groups{ groups }, m_configuration{ configuration }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {
@@ -99,17 +99,17 @@ const std::string& TransactionDialogController::getRGBA() const
 
 const std::string& TransactionDialogController::getTransactionDefaultColor() const
 {
-    return m_defaultColor;
+    return m_configuration.getTransactionDefaultColor();
 }
 
 std::string TransactionDialogController::getAmountAsString() const
 {
-    return MoneyHelpers::boostMoneyToLocaleString(m_transaction.getAmount(), m_locale);
+    return MoneyHelpers::boostMoneyToLocaleString(m_transaction.getAmount(), m_configuration.getLocale());
 }
 
 bool TransactionDialogController::isLocaleDotDecimalSeperated() const
 {
-    return MoneyHelpers::isLocaleDotDecimalSeperated(m_locale);
+    return MoneyHelpers::isLocaleDotDecimalSeperated(m_configuration.getLocale());
 }
 
 TransactionCheckStatus TransactionDialogController::updateTransaction(const std::string& dateString, const std::string& description, TransactionType type, int repeatInterval, int groupIndex, const std::string& rgba, std::string amountString)
@@ -122,7 +122,7 @@ TransactionCheckStatus TransactionDialogController::updateTransaction(const std:
     {
         return TransactionCheckStatus::EmptyAmount;
     }
-    boost::multiprecision::cpp_dec_float_50 amount{ MoneyHelpers::localeStringToBoostMoney(amountString, m_locale) };
+    boost::multiprecision::cpp_dec_float_50 amount{ MoneyHelpers::localeStringToBoostMoney(amountString, m_configuration.getLocale()) };
     if(amount == 0)
     {
         return TransactionCheckStatus::InvalidAmount;

--- a/src/controllers/transactiondialogcontroller.cpp
+++ b/src/controllers/transactiondialogcontroller.cpp
@@ -7,7 +7,7 @@ using namespace NickvisionMoney::Controllers;
 using namespace NickvisionMoney::Helpers;
 using namespace NickvisionMoney::Models;
 
-TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, const std::locale& locale) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ newId }, m_groups{ groups }
+TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, const std::locale& locale, Configuration& configuration) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ newId }, m_groups{ groups }, m_configuration{ configuration }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {
@@ -17,7 +17,7 @@ TransactionDialogController::TransactionDialogController(unsigned int newId, con
     m_groupNames.insert(m_groupNames.begin(), _("None"));
 }
 
-TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, const std::locale& locale) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ transaction }, m_groups{ groups }
+TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, const std::locale& locale, NickvisionMoney::Models::Configuration& configuration) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ transaction }, m_groups{ groups }, m_configuration{ configuration }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {
@@ -97,6 +97,10 @@ const std::string& TransactionDialogController::getRGBA() const
     return m_transaction.getRGBA();
 }
 
+const std::string& TransactionDialogController::getTransactionDefaultColor() const
+{
+    return m_configuration.getTransactionDefaultColor();
+}
 
 std::string TransactionDialogController::getAmountAsString() const
 {

--- a/src/controllers/transactiondialogcontroller.cpp
+++ b/src/controllers/transactiondialogcontroller.cpp
@@ -7,7 +7,7 @@ using namespace NickvisionMoney::Controllers;
 using namespace NickvisionMoney::Helpers;
 using namespace NickvisionMoney::Models;
 
-TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, Configuration& configuration) : m_response{ "cancel" }, m_transaction{ newId }, m_groups{ groups }, m_configuration{ configuration }
+TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, Configuration& configuration) : m_response{ "cancel" }, m_configuration{ configuration }, m_transaction{ newId }, m_groups{ groups }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {
@@ -17,7 +17,7 @@ TransactionDialogController::TransactionDialogController(unsigned int newId, con
     m_groupNames.insert(m_groupNames.begin(), _("None"));
 }
 
-TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, Configuration& configuration) : m_response{ "cancel" }, m_transaction{ transaction }, m_groups{ groups }, m_configuration{ configuration }
+TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, Configuration& configuration) : m_response{ "cancel" }, m_configuration{ configuration }, m_transaction{ transaction }, m_groups{ groups }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {

--- a/src/controllers/transactiondialogcontroller.cpp
+++ b/src/controllers/transactiondialogcontroller.cpp
@@ -7,7 +7,7 @@ using namespace NickvisionMoney::Controllers;
 using namespace NickvisionMoney::Helpers;
 using namespace NickvisionMoney::Models;
 
-TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, const std::locale& locale, Configuration& configuration) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ newId }, m_groups{ groups }, m_configuration{ configuration }
+TransactionDialogController::TransactionDialogController(unsigned int newId, const std::map<unsigned int, Group>& groups, const std::locale& locale, const std::string& defaultColor) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ newId }, m_groups{ groups }, m_defaultColor{ defaultColor }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {
@@ -17,7 +17,7 @@ TransactionDialogController::TransactionDialogController(unsigned int newId, con
     m_groupNames.insert(m_groupNames.begin(), _("None"));
 }
 
-TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, const std::locale& locale, NickvisionMoney::Models::Configuration& configuration) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ transaction }, m_groups{ groups }, m_configuration{ configuration }
+TransactionDialogController::TransactionDialogController(const Transaction& transaction, const std::map<unsigned int, Group>& groups, const std::locale& locale, const std::string& defaultColor) : m_response{ "cancel" }, m_locale{ locale }, m_transaction{ transaction }, m_groups{ groups }, m_defaultColor{ defaultColor }
 {
     for(const std::pair<const unsigned int, Group>& pair : m_groups)
     {
@@ -99,7 +99,7 @@ const std::string& TransactionDialogController::getRGBA() const
 
 const std::string& TransactionDialogController::getTransactionDefaultColor() const
 {
-    return m_configuration.getTransactionDefaultColor();
+    return m_defaultColor;
 }
 
 std::string TransactionDialogController::getAmountAsString() const

--- a/src/controllers/transactiondialogcontroller.hpp
+++ b/src/controllers/transactiondialogcontroller.hpp
@@ -33,18 +33,18 @@ namespace NickvisionMoney::Controllers
 		 * @param newId The Id of the new transaction
 		 * @param groups The groups of the account
 		 * @param locale The user's locale
-		 * @param configuration The Configuration for the application (Stored as a reference)
+		 * @param defaultColor Transaction Default Color
 		 */
-		TransactionDialogController(unsigned int newId, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, NickvisionMoney::Models::Configuration& configuration);
+		TransactionDialogController(unsigned int newId, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, const std::string& defaultColor);
 		/**
 		 * Constructs a TransactionDialogController
 		 *
 		 * @param transaction The transaction to update
 		 * @param groups The groups of the account
 		 * @param locale The user's locale
-		 * @param configuration The Configuration for the application (Stored as a reference)
+		 * @param defaultColor Transaction Default Color
 		 */
-		TransactionDialogController(const NickvisionMoney::Models::Transaction& transaction, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, NickvisionMoney::Models::Configuration& configuration);
+		TransactionDialogController(const NickvisionMoney::Models::Transaction& transaction, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, const std::string& defaultColor);
 		/**
 		 * Gets the response of the dialog
 		 *
@@ -161,6 +161,6 @@ namespace NickvisionMoney::Controllers
 		NickvisionMoney::Models::Transaction m_transaction;
 		std::map<unsigned int, NickvisionMoney::Models::Group> m_groups;
 		std::vector<std::string> m_groupNames;
-		NickvisionMoney::Models::Configuration& m_configuration;
+		const std::string& m_defaultColor;
 	};
 }

--- a/src/controllers/transactiondialogcontroller.hpp
+++ b/src/controllers/transactiondialogcontroller.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include "../models/group.hpp"
 #include "../models/transaction.hpp"
+#include "../models/configuration.hpp"
 
 namespace NickvisionMoney::Controllers
 {
@@ -32,16 +33,18 @@ namespace NickvisionMoney::Controllers
 		 * @param newId The Id of the new transaction
 		 * @param groups The groups of the account
 		 * @param locale The user's locale
+		 * @param configuration The Configuration for the application (Stored as a reference)
 		 */
-		TransactionDialogController(unsigned int newId, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale);
+		TransactionDialogController(unsigned int newId, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, NickvisionMoney::Models::Configuration& configuration);
 		/**
 		 * Constructs a TransactionDialogController
 		 *
 		 * @param transaction The transaction to update
 		 * @param groups The groups of the account
 		 * @param locale The user's locale
+		 * @param configuration The Configuration for the application (Stored as a reference)
 		 */
-		TransactionDialogController(const NickvisionMoney::Models::Transaction& transaction, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale);
+		TransactionDialogController(const NickvisionMoney::Models::Transaction& transaction, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, NickvisionMoney::Models::Configuration& configuration);
 		/**
 		 * Gets the response of the dialog
 		 *
@@ -115,11 +118,17 @@ namespace NickvisionMoney::Controllers
 		 */
 		int getGroupAsIndex() const;
 		/**
-         * Gets the rgba color of the transaction
-         *
-         * @returns The rgba color of the transaction
-         */
-        const std::string& getRGBA() const;
+         	 * Gets the rgba color of the transaction
+         	 *
+         	 * @returns The rgba color of the transaction
+         	 */
+        	const std::string& getRGBA() const;
+		/**
+		 * Gets transaction default color from configuration
+		 *
+		 * @returns Transaction default color
+		 */
+		const std::string& getTransactionDefaultColor() const;
 		/**
 		 * Gets the amount of the transaction as a string
 		 *
@@ -152,5 +161,6 @@ namespace NickvisionMoney::Controllers
 		NickvisionMoney::Models::Transaction m_transaction;
 		std::map<unsigned int, NickvisionMoney::Models::Group> m_groups;
 		std::vector<std::string> m_groupNames;
+		NickvisionMoney::Models::Configuration& m_configuration;
 	};
 }

--- a/src/controllers/transactiondialogcontroller.hpp
+++ b/src/controllers/transactiondialogcontroller.hpp
@@ -32,19 +32,17 @@ namespace NickvisionMoney::Controllers
 		 *
 		 * @param newId The Id of the new transaction
 		 * @param groups The groups of the account
-		 * @param locale The user's locale
-		 * @param defaultColor Transaction Default Color
+		 * @param configuration The Configuration for the application (Stored as a reference)
 		 */
-		TransactionDialogController(unsigned int newId, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, const std::string& defaultColor);
+		TransactionDialogController(unsigned int newId, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, NickvisionMoney::Models::Configuration& configuration);
 		/**
 		 * Constructs a TransactionDialogController
 		 *
 		 * @param transaction The transaction to update
 		 * @param groups The groups of the account
-		 * @param locale The user's locale
-		 * @param defaultColor Transaction Default Color
+		 * @param configuration The Configuration for the application (Stored as a reference)
 		 */
-		TransactionDialogController(const NickvisionMoney::Models::Transaction& transaction, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, const std::locale& locale, const std::string& defaultColor);
+		TransactionDialogController(const NickvisionMoney::Models::Transaction& transaction, const std::map<unsigned int, NickvisionMoney::Models::Group>& groups, NickvisionMoney::Models::Configuration& configuration);
 		/**
 		 * Gets the response of the dialog
 		 *
@@ -157,10 +155,9 @@ namespace NickvisionMoney::Controllers
 
 	private:
 		std::string m_response;
-		const std::locale& m_locale;
 		NickvisionMoney::Models::Transaction m_transaction;
 		std::map<unsigned int, NickvisionMoney::Models::Group> m_groups;
 		std::vector<std::string> m_groupNames;
-		const std::string& m_defaultColor;
+		NickvisionMoney::Models::Configuration& m_configuration;
 	};
 }

--- a/src/controllers/transactiondialogcontroller.hpp
+++ b/src/controllers/transactiondialogcontroller.hpp
@@ -155,9 +155,9 @@ namespace NickvisionMoney::Controllers
 
 	private:
 		std::string m_response;
+		NickvisionMoney::Models::Configuration& m_configuration;
 		NickvisionMoney::Models::Transaction m_transaction;
 		std::map<unsigned int, NickvisionMoney::Models::Group> m_groups;
 		std::vector<std::string> m_groupNames;
-		NickvisionMoney::Models::Configuration& m_configuration;
 	};
 }

--- a/src/models/configuration.cpp
+++ b/src/models/configuration.cpp
@@ -8,7 +8,7 @@
 
 using namespace NickvisionMoney::Models;
 
-Configuration::Configuration() : m_configDir{ std::string(g_get_user_config_dir()) + "/Nickvision/NickvisionMoney/" }, m_locale{ setlocale(LC_ALL, nullptr) }, m_theme{ Theme::System }, m_recentAccount1{ "" }, m_recentAccount2{ "" }, m_recentAccount3{ "" }, m_sortFirstToLast{ true }
+Configuration::Configuration() : m_configDir{ std::string(g_get_user_config_dir()) + "/Nickvision/NickvisionMoney/" }, m_locale{ setlocale(LC_ALL, nullptr) }, m_theme{ Theme::System }, m_recentAccount1{ "" }, m_recentAccount2{ "" }, m_recentAccount3{ "" }, m_sortFirstToLast{ true }, m_transactionDefaultColor{ "rgb(53,132,228)" }, m_transferDefaultColor{ "rgb(192,97,203)" }
 {
     //Load Config File
     if(!std::filesystem::exists(m_configDir))
@@ -25,6 +25,8 @@ Configuration::Configuration() : m_configDir{ std::string(g_get_user_config_dir(
         m_recentAccount2 = json.get("RecentAccount2", "").asString();
         m_recentAccount3 = json.get("RecentAccount3", "").asString();
         m_sortFirstToLast = json.get("SortFirstToLast", true).asBool();
+        m_transactionDefaultColor = json.get("TransactionDefaultColor", "rgb(53,132,228)").asString();
+        m_transferDefaultColor = json.get("TransferDefaultColor", "rgb(192,97,203)").asString();
     }
 }
 
@@ -56,6 +58,26 @@ const std::string& Configuration::getRecentAccount2() const
 const std::string& Configuration::getRecentAccount3() const
 {
     return m_recentAccount3;
+}
+
+const std::string& Configuration::getTransactionDefaultColor() const
+{
+    return m_transactionDefaultColor;
+}
+
+const std::string& Configuration::getTransferDefaultColor() const
+{
+    return m_transferDefaultColor;
+}
+
+void Configuration::setTransactionDefaultColor(std::string color)
+{
+    m_transactionDefaultColor = color;
+}
+
+void Configuration::setTransferDefaultColor(std::string color)
+{
+    m_transferDefaultColor = color;
 }
 
 void Configuration::addRecentAccount(const std::string& newRecentAccount)
@@ -107,6 +129,8 @@ void Configuration::save() const
         json["RecentAccount2"] = m_recentAccount2;
         json["RecentAccount3"] = m_recentAccount3;
         json["SortFirstToLast"] = m_sortFirstToLast;
+        json["TransactionDefaultColor"] = m_transactionDefaultColor;
+        json["TransferDefaultColor"] = m_transferDefaultColor;
         configFile << json;
     }
 }

--- a/src/models/configuration.hpp
+++ b/src/models/configuration.hpp
@@ -62,6 +62,30 @@ namespace NickvisionMoney::Models
 		 */
 		const std::string& getRecentAccount3() const;
 		/**
+		 * Gets transaction default color
+		 *
+		 * @returns Transaction default color (RGB string)
+		 */
+		const std::string& getTransactionDefaultColor() const;
+		/**
+		 * Gets transfer default color
+		 *
+		 * @returns Transfer default color (RGB string)
+		 */
+		const std::string& getTransferDefaultColor() const;
+		/**
+		 * Sets transaction default color
+		 *
+		 * @param color The new transaction default color (RGB string)
+		 */
+		void setTransactionDefaultColor(std::string color);
+		/**
+		 * Sets transfer default color
+		 *
+		 * @param color The new transfer default color (RGB string)
+		 */
+		void setTransferDefaultColor(std::string color);
+		/**
 		 * Adds a recent account to the list of recent accounts
 		 *
 		 * @param newRecentAccount The new recent account to add to the list
@@ -92,5 +116,7 @@ namespace NickvisionMoney::Models
 		std::string m_recentAccount2;
 		std::string m_recentAccount3;
 		bool m_sortFirstToLast;
+		std::string m_transactionDefaultColor;
+		std::string m_transferDefaultColor;
 	};
 }

--- a/src/models/transaction.cpp
+++ b/src/models/transaction.cpp
@@ -3,7 +3,7 @@
 
 using namespace NickvisionMoney::Models;
 
-Transaction::Transaction(unsigned int id) : m_id{ id }, m_date{ boost::gregorian::day_clock::local_day() }, m_description{ "" }, m_type{ TransactionType::Income }, m_repeatInterval{ RepeatInterval::Never }, m_amount{ 0.00 }, m_groupId{ -1 }, m_rgba{ "#3584e4" }
+Transaction::Transaction(unsigned int id) : m_id{ id }, m_date{ boost::gregorian::day_clock::local_day() }, m_description{ "" }, m_type{ TransactionType::Income }, m_repeatInterval{ RepeatInterval::Never }, m_amount{ 0.00 }, m_groupId{ -1 }, m_rgba{ "" }
 {
 
 }

--- a/src/ui/views/preferencesdialog.cpp
+++ b/src/ui/views/preferencesdialog.cpp
@@ -25,6 +25,12 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     adw_combo_row_set_model(ADW_COMBO_ROW(m_rowTheme), G_LIST_MODEL(gtk_string_list_new(new const char*[4]{ _("System"), _("Light"), _("Dark"), nullptr })));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTheme);
     g_signal_connect(m_rowTheme, "notify::selected-item", G_CALLBACK((void (*)(GObject*, GParamSpec*, gpointer))[](GObject*, GParamSpec*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onThemeChanged(); }), this);
+    //Transaction Default Color Row
+    m_btnTransactionColor = gtk_color_button_new();
+    m_rowTransactionColor = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTransactionColor), _("Transaction Default Color"));
+    adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowTransactionColor), m_btnTransactionColor);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTransactionColor);
     //Page
     m_page = adw_preferences_page_new();
     adw_preferences_page_add(ADW_PREFERENCES_PAGE(m_page), ADW_PREFERENCES_GROUP(m_grpUserInterface));

--- a/src/ui/views/preferencesdialog.cpp
+++ b/src/ui/views/preferencesdialog.cpp
@@ -26,9 +26,7 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTheme);
     g_signal_connect(m_rowTheme, "notify::selected-item", G_CALLBACK((void (*)(GObject*, GParamSpec*, gpointer))[](GObject*, GParamSpec*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onThemeChanged(); }), this);
     //Transaction Default Color Row
-    GdkRGBA transactionColor;
-    gdk_rgba_parse(&transactionColor, m_controller.getTransactionDefaultColor().c_str());
-    m_btnTransactionColor = gtk_color_button_new_with_rgba(&transactionColor);
+    m_btnTransactionColor = gtk_color_button_new();
     gtk_widget_set_valign(m_btnTransactionColor, GTK_ALIGN_CENTER);
     g_signal_connect(m_btnTransactionColor, "color-set", G_CALLBACK((void (*)(GtkColorButton*, gpointer))[](GtkColorButton*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onTransactionColorSet(); }), this);
     m_rowTransactionColor = adw_action_row_new();
@@ -38,9 +36,7 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_rowTransactionColor), m_btnTransactionColor);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTransactionColor);
     //Transfer Default Color Row
-    GdkRGBA transferColor;
-    gdk_rgba_parse(&transferColor, m_controller.getTransferDefaultColor().c_str());
-    m_btnTransferColor = gtk_color_button_new_with_rgba(&transferColor);
+    m_btnTransferColor = gtk_color_button_new();
     gtk_widget_set_valign(m_btnTransferColor, GTK_ALIGN_CENTER);
     g_signal_connect(m_btnTransferColor, "color-set", G_CALLBACK((void (*)(GtkColorButton*, gpointer))[](GtkColorButton*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onTransferColorSet(); }), this);
     m_rowTransferColor = adw_action_row_new();
@@ -59,6 +55,12 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     adw_window_set_content(ADW_WINDOW(m_gobj), m_mainBox);
     //Load Configuration
     adw_combo_row_set_selected(ADW_COMBO_ROW(m_rowTheme), m_controller.getThemeAsInt());
+    GdkRGBA transactionColor;
+    gdk_rgba_parse(&transactionColor, m_controller.getTransactionDefaultColor().c_str());
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(m_btnTransactionColor), &transactionColor);
+    GdkRGBA transferColor;
+    gdk_rgba_parse(&transferColor, m_controller.getTransferDefaultColor().c_str());
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(m_btnTransferColor), &transferColor);
 }
 
 GtkWidget* PreferencesDialog::gobj()

--- a/src/ui/views/preferencesdialog.cpp
+++ b/src/ui/views/preferencesdialog.cpp
@@ -33,6 +33,7 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     g_signal_connect(m_btnTransactionColor, "color-set", G_CALLBACK((void (*)(GtkColorButton*, gpointer))[](GtkColorButton*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onTransactionColorSet(); }), this);
     m_rowTransactionColor = adw_action_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTransactionColor), _("Transaction Default Color"));
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(m_rowTransactionColor), _("A change in this setting will only be applied to newly added transactions."));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowTransactionColor), m_btnTransactionColor);
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_rowTransactionColor), m_btnTransactionColor);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTransactionColor);
@@ -44,6 +45,7 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     g_signal_connect(m_btnTransferColor, "color-set", G_CALLBACK((void (*)(GtkColorButton*, gpointer))[](GtkColorButton*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onTransferColorSet(); }), this);
     m_rowTransferColor = adw_action_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTransferColor), _("Transfer Default Color"));
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(m_rowTransferColor), _("A change in this setting will only be applied to newly added transactions."));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowTransferColor), m_btnTransferColor);
     adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_rowTransferColor), m_btnTransferColor);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTransferColor);

--- a/src/ui/views/preferencesdialog.cpp
+++ b/src/ui/views/preferencesdialog.cpp
@@ -26,11 +26,27 @@ PreferencesDialog::PreferencesDialog(GtkWindow* parent, const PreferencesDialogC
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTheme);
     g_signal_connect(m_rowTheme, "notify::selected-item", G_CALLBACK((void (*)(GObject*, GParamSpec*, gpointer))[](GObject*, GParamSpec*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onThemeChanged(); }), this);
     //Transaction Default Color Row
-    m_btnTransactionColor = gtk_color_button_new();
+    GdkRGBA transactionColor;
+    gdk_rgba_parse(&transactionColor, m_controller.getTransactionDefaultColor().c_str());
+    m_btnTransactionColor = gtk_color_button_new_with_rgba(&transactionColor);
+    gtk_widget_set_valign(m_btnTransactionColor, GTK_ALIGN_CENTER);
+    g_signal_connect(m_btnTransactionColor, "color-set", G_CALLBACK((void (*)(GtkColorButton*, gpointer))[](GtkColorButton*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onTransactionColorSet(); }), this);
     m_rowTransactionColor = adw_action_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTransactionColor), _("Transaction Default Color"));
     adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowTransactionColor), m_btnTransactionColor);
+    adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_rowTransactionColor), m_btnTransactionColor);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTransactionColor);
+    //Transfer Default Color Row
+    GdkRGBA transferColor;
+    gdk_rgba_parse(&transferColor, m_controller.getTransferDefaultColor().c_str());
+    m_btnTransferColor = gtk_color_button_new_with_rgba(&transferColor);
+    gtk_widget_set_valign(m_btnTransferColor, GTK_ALIGN_CENTER);
+    g_signal_connect(m_btnTransferColor, "color-set", G_CALLBACK((void (*)(GtkColorButton*, gpointer))[](GtkColorButton*, gpointer data) { reinterpret_cast<PreferencesDialog*>(data)->onTransferColorSet(); }), this);
+    m_rowTransferColor = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_rowTransferColor), _("Transfer Default Color"));
+    adw_action_row_add_suffix(ADW_ACTION_ROW(m_rowTransferColor), m_btnTransferColor);
+    adw_action_row_set_activatable_widget(ADW_ACTION_ROW(m_rowTransferColor), m_btnTransferColor);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(m_grpUserInterface), m_rowTransferColor);
     //Page
     m_page = adw_preferences_page_new();
     adw_preferences_page_add(ADW_PREFERENCES_PAGE(m_page), ADW_PREFERENCES_GROUP(m_grpUserInterface));
@@ -74,4 +90,18 @@ void PreferencesDialog::onThemeChanged()
     {
         adw_style_manager_set_color_scheme(adw_style_manager_get_default(), ADW_COLOR_SCHEME_FORCE_DARK);
     }
+}
+
+void PreferencesDialog::onTransactionColorSet()
+{
+    GdkRGBA color;
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(m_btnTransactionColor), &color);
+    m_controller.setTransactionDefaultColor(gdk_rgba_to_string(&color));
+}
+
+void PreferencesDialog::onTransferColorSet()
+{
+    GdkRGBA color;
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(m_btnTransferColor), &color);
+    m_controller.setTransferDefaultColor(gdk_rgba_to_string(&color));
 }

--- a/src/ui/views/preferencesdialog.hpp
+++ b/src/ui/views/preferencesdialog.hpp
@@ -37,9 +37,21 @@ namespace NickvisionMoney::UI::Views
 		GtkWidget* m_page{ nullptr };
 		GtkWidget* m_grpUserInterface{ nullptr };
 		GtkWidget* m_rowTheme{ nullptr };
+		GtkWidget* m_btnTransactionColor{ nullptr };
+		GtkWidget* m_rowTransactionColor{ nullptr };
+		GtkWidget* m_btnTransferColor{ nullptr };
+		GtkWidget* m_rowTransferColor{ nullptr };
 		/**
 		 * Ocurrs when the theme row is changed
 		 */
 		void onThemeChanged();
+		/**
+		 * Occurs when the transaction color chooser's value is set
+		 */
+		void onTransactionColorSet();
+		/**
+		 * Occurs when the transfer color chooser's value is set
+		 */
+		void onTransferColorSet();
 	};
 }

--- a/src/ui/views/transactiondialog.cpp
+++ b/src/ui/views/transactiondialog.cpp
@@ -119,7 +119,7 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, TransactionDialogControl
     GdkRGBA color;
     if(!gdk_rgba_parse(&color, m_controller.getRGBA().c_str()))
     {
-        gdk_rgba_parse(&color, "#3584e4");
+        gdk_rgba_parse(&color, m_controller.getTransactionDefaultColor().c_str());
     }
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(m_btnColor), &color);
     gtk_editable_set_text(GTK_EDITABLE(m_rowAmount), m_controller.getAmountAsString().c_str());


### PR DESCRIPTION
![](https://i.imgur.com/3XA23AS.png)

Changing colors settings doesn't affect existing transactions, even if they use default color. For transfer transaction, `purple_2` is used because:
1. It looks good with both light and dark theme;
2. It's close enough to the default blue, but different enough to be easy to notice (at least for non-color-blind users);
3. It doesn't have a fixed meaning in Adwaita design.

New strings use gettext, but I didn't regenerate PO files since we'll do it later anyway when more strings will be added.