### PR TITLE
Change calendar behaviour in TransactionDialog

### DIFF
--- a/src/ui/views/transactiondialog.cpp
+++ b/src/ui/views/transactiondialog.cpp
@@ -57,7 +57,11 @@ TransactionDialog::TransactionDialog(GtkWindow* parent, TransactionDialogControl
     //Date
     m_calendarDate = gtk_calendar_new();
     gtk_widget_set_name(m_calendarDate, "calendarTransactions");
-    g_signal_connect(m_calendarDate, "day-selected", G_CALLBACK((void (*)(GtkCalendar*, gpointer))([](GtkCalendar*, gpointer data) { reinterpret_cast<TransactionDialog*>(data)->onDateChanged(); })), this);
+    const std::string calendar_signals[5]{"day-selected", "next-month", "next-year", "prev-month", "prev-year"};
+    for(std::string signal : calendar_signals)
+    {
+        g_signal_connect(m_calendarDate, signal.c_str(), G_CALLBACK((void (*)(GtkCalendar*, gpointer))([](GtkCalendar*, gpointer data) { reinterpret_cast<TransactionDialog*>(data)->onDateChanged(); })), this);
+    }
     m_popoverDate = gtk_popover_new();
     gtk_popover_set_child(GTK_POPOVER(m_popoverDate), m_calendarDate);
     m_btnDate = gtk_menu_button_new();
@@ -186,7 +190,6 @@ void TransactionDialog::setResponse(const std::string& response)
 void TransactionDialog::onDateChanged()
 {
     gtk_menu_button_set_label(GTK_MENU_BUTTON(m_btnDate), g_date_time_format(gtk_calendar_get_date(GTK_CALENDAR(m_calendarDate)), "%x"));
-    gtk_popover_popdown(GTK_POPOVER(m_popoverDate));
 }
 
 void TransactionDialog::onTypeChanged()


### PR DESCRIPTION
* Function to change label is now connected to all calendar signals
* Popover with calendar is not hidden automatically anymore. The reason is that <del>`Gtk.Calendar` is so old and stupid widget that causes us so much pain</del> even if we had two functions (one for `day-selected` and another for everything else) if for example you select 31th Jan, then change month to Feb, the date is changed to 28th Feb, which automatically emits `day-selected` signal and closes the popover. This is unexpected behavior for the user so I think it's better to let the user close the popover manually after the date is set.

Closes #129 