### PR TITLE
Disable markup in transaction and group rows

### DIFF
--- a/src/ui/controls/grouprow.cpp
+++ b/src/ui/controls/grouprow.cpp
@@ -10,6 +10,7 @@ using namespace NickvisionMoney::UI::Controls;
 GroupRow::GroupRow(const Group& group, const std::locale& locale, bool filterActive) : m_group{ group }, m_gobj{ adw_action_row_new() }
 {
     //Row Settings
+    adw_preferences_row_set_use_markup(ADW_PREFERENCES_ROW(m_gobj), false);
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_gobj), m_group.getName().c_str());
     adw_action_row_set_subtitle(ADW_ACTION_ROW(m_gobj), m_group.getDescription().c_str());
     //Filter Checkbox

--- a/src/ui/controls/transactionrow.cpp
+++ b/src/ui/controls/transactionrow.cpp
@@ -14,6 +14,7 @@ TransactionRow::TransactionRow(const Transaction& transaction, const std::locale
     m_row = adw_action_row_new();
     std::stringstream builder;
     builder << m_transaction.getDescription();
+    adw_preferences_row_set_use_markup(ADW_PREFERENCES_ROW(m_row), false);
     adw_action_row_set_title_lines(ADW_ACTION_ROW(m_row), 1);
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(m_row), builder.str().c_str());
     builder.str("");


### PR DESCRIPTION
By default markup is enabled for titles in `Adw.PreferencesRow`. `&` is special symbol that can cause markup error if not used properly, resulting in empty string. To show `&` in markup string one should use `&amp;`, but we don't need markup in transaction and group rows, so I disabled it.

![](https://i.imgur.com/iD0jFUd.png)
![](https://i.imgur.com/CdCsZto.png)

Closes #134 