### PR TITLE
GNOME - Fix GResource location

### DIFF
--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -35,8 +35,15 @@ public class Program
         Adw.Module.Initialize();
         _application = Adw.Application.New("org.nickvision.money", Gio.ApplicationFlags.FlagsNone);
         _application.OnActivate += OnActivate;
-        var prefix = Directory.GetParent(Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName).FullName;
-        g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
+        if(File.Exists("/usr/share/org.nickvision.money/org.nickvision.money.gresource"))
+        {
+            g_resources_register(g_resource_load(Path.GetFullPath("/usr/share/org.nickvision.money/org.nickvision.money.gresource")));
+        }
+        else
+        {
+            var prefix = Directory.GetParent(Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName).FullName;
+            g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
+        }
     }
 
     /// <summary>

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -35,13 +35,14 @@ public class Program
         Adw.Module.Initialize();
         _application = Adw.Application.New("org.nickvision.money", Gio.ApplicationFlags.FlagsNone);
         _application.OnActivate += OnActivate;
-        if(File.Exists("/usr/share/org.nickvision.money/org.nickvision.money.gresource"))
-        {
-            g_resources_register(g_resource_load(Path.GetFullPath("/usr/share/org.nickvision.money/org.nickvision.money.gresource")));
-        }
-        else
+        try
         {
             var prefix = Directory.GetParent(Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName).FullName;
+            g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
+        }
+        catch
+        {
+            var prefix = Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName;
             g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
         }
     }

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -2,6 +2,7 @@
 using NickvisionMoney.Shared.Controllers;
 using NickvisionMoney.Shared.Models;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -35,15 +36,18 @@ public class Program
         Adw.Module.Initialize();
         _application = Adw.Application.New("org.nickvision.money", Gio.ApplicationFlags.FlagsNone);
         _application.OnActivate += OnActivate;
-        try
+        var prefixes = new List<string> {
+            Directory.GetParent(Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName).FullName,
+            Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName,
+            "/usr"
+        };
+        foreach(var prefix in prefixes)
         {
-            var prefix = Directory.GetParent(Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName).FullName;
-            g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
-        }
-        catch
-        {
-            var prefix = Directory.GetParent(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))).FullName;
-            g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
+            if(File.Exists(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource"))
+            {
+                g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
If the app is installed in `/opt` the gresource will not be found, so let the app first look in `/usr/share` and only then in `../../share`