### PR TITLE
GNOME - Add button to show/hide groups

### DIFF
--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -236,6 +236,7 @@ public partial class AccountView
         //Button Toggle Groups
         _btnToggleGroups = Gtk.ToggleButton.New();
         _btnToggleGroups.AddCssClass("flat");
+        _btnToggleGroups.SetTooltipText(_controller.Localizer["ToggleGroups", "Tooltip"]);
         _btnToggleGroups.OnToggled += OnToggleGroups;
         _btnToggleGroupsContent = Adw.ButtonContent.New();
         _btnToggleGroups.SetChild(_btnToggleGroupsContent);

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -90,6 +90,8 @@ public partial class AccountView
     private readonly Gtk.Button _btnResetOverviewFilter;
     private readonly Adw.PreferencesGroup _grpOverview;
     private readonly Gtk.Box _boxButtonsGroups;
+    private readonly Gtk.ToggleButton _btnToggleGroups;
+    private readonly Adw.ButtonContent _btnToggleGroupsContent;
     private readonly Gtk.Button _btnNewGroup;
     private readonly Adw.ButtonContent _btnNewGroupContent;
     private readonly Gtk.Button _btnResetGroupsFilter;
@@ -231,6 +233,13 @@ public partial class AccountView
         _paneBox.Append(_grpOverview);
         //Group Buttons Box
         _boxButtonsGroups = Gtk.Box.New(Gtk.Orientation.Horizontal, 6);
+        //Button Toggle Groups
+        _btnToggleGroups = Gtk.ToggleButton.New();
+        _btnToggleGroups.AddCssClass("flat");
+        _btnToggleGroups.OnToggled += OnToggleGroups;
+        _btnToggleGroupsContent = Adw.ButtonContent.New();
+        _btnToggleGroups.SetChild(_btnToggleGroupsContent);
+        _boxButtonsGroups.Append(_btnToggleGroups);
         //Button New Group
         _btnNewGroup = Gtk.Button.New();
         _btnNewGroup.AddCssClass("flat");
@@ -446,6 +455,7 @@ public partial class AccountView
         _flap.AddController(_shortcutController);
         //Load
         OnAccountInfoChanged(null, EventArgs.Empty);
+        OnToggleGroups(null, EventArgs.Empty);
         _parentWindow.OnWidthChanged();
     }
 
@@ -611,6 +621,29 @@ public partial class AccountView
         if(dialog.Run() == MessageDialogResponse.Destructive)
         {
             await _controller.DeleteGroupAsync(id);
+        }
+    }
+
+    /// <summary>
+    /// Occurs when the user presses the button to show/hide groups
+    /// </summary>
+    /// <param name="sender">object?</param>
+    /// <param name="e">EventArgs</param>
+    private void OnToggleGroups(object? sender, EventArgs e)
+    {
+        if(_btnToggleGroups.GetActive())
+        {
+            _btnToggleGroupsContent.SetIconName("view-reveal-symbolic");
+            _btnToggleGroupsContent.SetLabel(_controller.Localizer["Show"]);
+        }
+        else
+        {
+            _btnToggleGroupsContent.SetIconName("view-conceal-symbolic");
+            _btnToggleGroupsContent.SetLabel(_controller.Localizer["Hide"]);
+        }
+        foreach(var groupRow in _groupRows)
+        {
+            groupRow.SetVisible(!_btnToggleGroups.GetActive());
         }
     }
 

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -455,7 +455,6 @@ public partial class AccountView
         _flap.AddController(_shortcutController);
         //Load
         OnAccountInfoChanged(null, EventArgs.Empty);
-        OnToggleGroups(null, EventArgs.Empty);
         _parentWindow.OnWidthChanged();
     }
 
@@ -506,6 +505,7 @@ public partial class AccountView
                 _grpGroups.Add(row);
                 _groupRows.Add(row);
             }
+            OnToggleGroups(null, EventArgs.Empty);
             //Transactions
             foreach (var transactionRow in _transactionRows)
             {

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -338,6 +338,14 @@
 		<value>This account has no money available to transfer.</value>
 	</data>
 
+	<data name="Hide" xml:space="preserve">
+		<value>Hide</value>
+	</data>
+
+	<data name="Show" xml:space="preserve">
+		<value>Show</value>
+	</data>
+
 	<!--AccountViewController-->
 	<data name="Ungrouped" xml:space="preserve">
 		<value>Ungrouped</value>

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -346,6 +346,10 @@
 		<value>Show</value>
 	</data>
 
+	<data name="ToggleGroups.Tooltip" xml:space="preserve">
+		<value>Toggle Groups Visibility</value>
+	</data>
+
 	<!--AccountViewController-->
 	<data name="Ungrouped" xml:space="preserve">
 		<value>Ungrouped</value>

--- a/NickvisionMoney.Shared/Resources/Strings.ru.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.ru.resx
@@ -346,6 +346,10 @@
 		<value>Показать</value>
 	</data>
 
+	<data name="ToggleGroups.Tooltip" xml:space="preserve">
+		<value>Переключить отображение групп</value>
+	</data>
+
 	<!--AccountViewController-->
 	<data name="Ungrouped" xml:space="preserve">
 		<value>Несгруппированные</value>

--- a/NickvisionMoney.Shared/Resources/Strings.ru.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.ru.resx
@@ -338,6 +338,14 @@
 		<value>На этом счёте нет средств для перевода.</value>
 	</data>
 
+	<data name="Hide" xml:space="preserve">
+		<value>Скрыть</value>
+	</data>
+
+	<data name="Show" xml:space="preserve">
+		<value>Показать</value>
+	</data>
+
 	<!--AccountViewController-->
 	<data name="Ungrouped" xml:space="preserve">
 		<value>Несгруппированные</value>


### PR DESCRIPTION
Making groups list scrollable creates some UI problems that are not easy to fix, so instead I added show/hide button as was suggested by @brunnogama. Closes #140 

![](https://i.imgur.com/SnzFcEo.png)
![](https://i.imgur.com/kQ6qpW9.png)