### PR TITLE
Make manifests build from current directory

### DIFF
--- a/NickvisionMoney.GNOME/org.nickvision.money-gnomebuilder.json
+++ b/NickvisionMoney.GNOME/org.nickvision.money-gnomebuilder.json
@@ -40,9 +40,8 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/nlogozzo/NickvisionMoney.git",
-                     "tag": "2023.1.0-beta1"
+                    "type": "dir",
+                    "path": ".."
                 }
             ]
         }

--- a/NickvisionMoney.GNOME/org.nickvision.money.json
+++ b/NickvisionMoney.GNOME/org.nickvision.money.json
@@ -61,9 +61,8 @@
             "sources": [
                 "sources.json",
                 {
-                    "type": "git",
-                    "url": "https://github.com/nlogozzo/NickvisionMoney.git",
-                    "tag": "2023.1.0-beta1"
+                    "type": "dir",
+                    "path": ".."
                 }
             ]
         }


### PR DESCRIPTION
GNOME Builder ignores sources lines for main module and builds the app from current directory anyway, so I didn't notice that in the default manifest sources point to specific commit, thus not allowing to test current changes.
Going to add the same fix to Application.