### PR TITLE
NickvisionMoney.GNOME/install_extras.sh: misc fixes

### DIFF
--- a/NickvisionMoney.GNOME/install_extras.sh
+++ b/NickvisionMoney.GNOME/install_extras.sh
@@ -1,46 +1,57 @@
-#!/bin/bash
+#!/bin/sh
 
 INSTALL_PREFIX="/usr"
-if [ ! -z $1 ]
+if [ -n "${1}" ]
 then
-	INSTALL_PREFIX=$1
+    INSTALL_PREFIX="${1}"
 fi
-echo Install prefix: $INSTALL_PREFIX
+echo Install prefix: "${INSTALL_PREFIX}"
 
-if [ ${PWD##*/} == "NickvisionMoney.GNOME" ]
+if [ "$(basename "$(pwd)")" = "NickvisionMoney.GNOME" ]
 then
-	cd ..
+    cd ..
 fi
 
-echo Installing icons...
-mkdir -p $INSTALL_PREFIX/share/icons/hicolor/scalable/apps
-cp ./NickvisionMoney.Shared/Resources/org.nickvision.money.svg $INSTALL_PREFIX/share/icons/hicolor/scalable/apps/
-cp ./NickvisionMoney.Shared/Resources/org.nickvision.money-devel.svg $INSTALL_PREFIX/share/icons/hicolor/scalable/apps/
-mkdir -p $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps
-cp ./NickvisionMoney.Shared/Resources/bank-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
-cp ./NickvisionMoney.Shared/Resources/larger-brush-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
-cp ./NickvisionMoney.Shared/Resources/money-none-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
-cp ./NickvisionMoney.Shared/Resources/moon-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
-cp ./NickvisionMoney.Shared/Resources/org.nickvision.money-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
-cp ./NickvisionMoney.Shared/Resources/sun-alt-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
-cp ./NickvisionMoney.Shared/Resources/wallet2-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
+echo "Installing icons..."
+mkdir -p "${INSTALL_PREFIX}"/share/icons/hicolor/scalable/apps
+for icon in org.nickvision.money.svg org.nickvision.money-devel.svg
+do
+    cp ./NickvisionMoney.Shared/Resources/${icon}               \
+       "${INSTALL_PREFIX}"/share/icons/hicolor/scalable/apps/
+done
+mkdir -p "${INSTALL_PREFIX}"/share/icons/hicolor/symbolic/apps
+for icon in bank-symbolic.svg                       \
+                larger-brush-symbolic.svg           \
+                money-none-symbolic.svg             \
+                moon-symbolic.svg                   \
+                org.nickvision.money-symbolic.svg   \
+                sun-alt-symbolic.svg                \
+                wallet2-symbolic.svg
+do
+    cp ./NickvisionMoney.Shared/Resources/${icon}               \
+       "${INSTALL_PREFIX}"/share/icons/hicolor/symbolic/apps/
+done
 
-echo Installing GResource...
-mkdir -p $INSTALL_PREFIX/share/org.nickvision.money
+echo "Installing GResource..."
+mkdir -p "${INSTALL_PREFIX}"/share/org.nickvision.money
 glib-compile-resources ./NickvisionMoney.GNOME/Resources/org.nickvision.money.gresource.xml
-mv ./NickvisionMoney.GNOME/Resources/org.nickvision.money.gresource $INSTALL_PREFIX/share/org.nickvision.money/
+mv ./NickvisionMoney.GNOME/Resources/org.nickvision.money.gresource \
+   "${INSTALL_PREFIX}"/share/org.nickvision.money/
 
-echo Installing desktop file...
-mkdir -p $INSTALL_PREFIX/share/applications
-cp ./NickvisionMoney.GNOME/org.nickvision.money.desktop $INSTALL_PREFIX/share/applications/
+echo "Installing desktop file..."
+mkdir -p "${INSTALL_PREFIX}"/share/applications
+cp ./NickvisionMoney.GNOME/org.nickvision.money.desktop \
+   "${INSTALL_PREFIX}"/share/applications/
 
-echo Installing metainfo...
-mkdir -p $INSTALL_PREFIX/share/metainfo
-cp ./NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml $INSTALL_PREFIX/share/metainfo/
+echo "Installing metainfo..."
+mkdir -p "${INSTALL_PREFIX}"/share/metainfo
+cp ./NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml    \
+   "${INSTALL_PREFIX}"/share/metainfo/
 
-echo Installing mime types...
-mkdir -p $INSTALL_PREFIX/share/mime/packages
-cp ./NickvisionMoney.GNOME/org.nickvision.money.extension.xml $INSTALL_PREFIX/share/mime/packages/
-update-mime-database $INSTALL_PREFIX/share/mime/
+echo "Installing mime types..."
+mkdir -p "${INSTALL_PREFIX}"/share/mime/packages
+cp ./NickvisionMoney.GNOME/org.nickvision.money.extension.xml   \
+   "${INSTALL_PREFIX}"/share/mime/packages/
+update-mime-database "${INSTALL_PREFIX}"/share/mime/
 
-echo Done!
+echo "Done!"


### PR DESCRIPTION
- break up long lines
- change the interpreter to sh (and conform to POSIX)
- make the script executable
- quote echo strings
- quote sensitive variables
- turn repetitive actions into for-loops
- use basename + pwd instead of bash-specific syntax

Signed-off-by: Maciej Barć <xgqt@gentoo.org>