### PR TITLE
Improve CSS overriding

### DIFF
--- a/NickvisionMoney.GNOME/Controls/GroupRow.cs
+++ b/NickvisionMoney.GNOME/Controls/GroupRow.cs
@@ -55,7 +55,7 @@ public partial class GroupRow : Adw.ActionRow
         //Amount Label
         _lblAmount = Gtk.Label.New($"{(_group.Balance >= 0 ? "+  " : "-  ")}{Math.Abs(_group.Balance).ToString("C")}");
         _lblAmount.AddCssClass(_group.Balance >= 0 ? "success" : "error");
-        _lblAmount.AddCssClass(_group.Balance >= 0 ? "money-income" : "money-expense");
+        _lblAmount.AddCssClass(_group.Balance >= 0 ? "denaro-income" : "denaro-expense");
         _lblAmount.SetValign(Gtk.Align.Center);
         //Edit Button
         _btnEdit = Gtk.Button.NewFromIconName("document-edit-symbolic");

--- a/NickvisionMoney.GNOME/Controls/TransactionRow.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionRow.cs
@@ -103,7 +103,7 @@ public partial class TransactionRow : Adw.PreferencesGroup
         _lblAmount.SetValign(Gtk.Align.Center);
         _lblAmount.SetMarginEnd(4);
         _lblAmount.AddCssClass(_transaction.Type == TransactionType.Income ? "success" : "error");
-        _lblAmount.AddCssClass(_transaction.Type == TransactionType.Income ? "money-income" : "money-expense");
+        _lblAmount.AddCssClass(_transaction.Type == TransactionType.Income ? "denaro-income" : "denaro-expense");
         //Edit Button
         _btnEdit = Gtk.Button.NewFromIconName("document-edit-symbolic");
         _btnEdit.SetValign(Gtk.Align.Center);

--- a/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
+++ b/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
@@ -1,6 +1,14 @@
 .wallet-button {
-	background-color: #00000000;
+  background-color: #00000000;
 }
+
+/* Calendars colors */
+@define-color denaro_calendar_today_bg_color @headerbar_bg_color;
+@define-color denaro_calendar_today_fg_color @warning_color;
+@define-color denaro_calendar_marked_day_fg_color @accent_color;
+@define-color denaro_calendar_selected_day_bg_color @accent_bg_color;
+@define-color denaro_calendar_delected_day_fg_color @fg_color;
+@define-color denaro_calendar_other_month_fg_color @light_5;
 
 /* Account View Calendar */
 #calendarAccount {
@@ -13,33 +21,33 @@
 }
 
 #calendarAccount .day-number {
-	border-radius: 12px;
+  border-radius: 12px;
 }
 
 #calendarAccount .today {
-	background-color: @headerbar_bg_color;
-	color: @warning_color;
-	box-shadow: none;
+  background-color: @denaro_calendar_today_bg_color;
+  color: @denaro_calendar_today_fg_color;
+  box-shadow: none;
 }
 
 #calendarAccount .day-number:checked {
-  color: @accent_color;
+  color: @denaro_calendar_marked_day_fg_color;
   font-weight: bold;
 }
 
 #calendarAccount .day-number:selected {
-  background-color: @accent_bg_color;
-  color: @fg_color;
+  background-color: @denaro_calendar_selected_day_bg_color;
+  color: @denaro_calendar_selected_day_fg_color;
 }
 
 #calendarAccount .other-month {
-	color: @light_5;
-	font-weight: normal;
+  color: @denaro_calendar_other_month_fg_color;
+  font-weight: normal;
 }
 
 #calendarAccount .other-month:checked {
-	color: @light_5;
-	font-weight: normal;
+  color: @denaro_calendar_other_month_fg_color;
+  font-weight: normal;
 }
 
 
@@ -49,13 +57,13 @@
 }
 
 #calendarTransactions .day-number {
-	border-radius: 12px;
+  border-radius: 12px;
 }
 
 #calendarTransactions .today {
-	background-color: @headerbar_bg_color;
-	color: @warning_color;
-	box-shadow: none;
+  background-color: @denaro_calendar_today_bg_color;
+  color: @denaro_calendar_today_fg_color;
+  box-shadow: none;
 }
 
 

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -178,7 +178,7 @@ public partial class AccountView
         _lblTotal = Gtk.Label.New("");
         _lblTotal.SetValign(Gtk.Align.Center);
         _lblTotal.AddCssClass("accent");
-        _lblTotal.AddCssClass("money-total");
+        _lblTotal.AddCssClass("denaro-total");
         _rowTotal = Adw.ActionRow.New();
         _rowTotal.SetTitle(_controller.Localizer["Total"]);
         _rowTotal.AddSuffix(_lblTotal);
@@ -186,7 +186,7 @@ public partial class AccountView
         _lblIncome = Gtk.Label.New("");
         _lblIncome.SetValign(Gtk.Align.Center);
         _lblIncome.AddCssClass("success");
-        _lblTotal.AddCssClass("money-income");
+        _lblTotal.AddCssClass("denaro-income");
         _chkIncome = Gtk.CheckButton.New();
         _chkIncome.SetActive(true);
         _chkIncome.AddCssClass("selection-mode");
@@ -199,7 +199,7 @@ public partial class AccountView
         _lblExpense = Gtk.Label.New("");
         _lblExpense.SetValign(Gtk.Align.Center);
         _lblExpense.AddCssClass("error");
-        _lblExpense.AddCssClass("money-expense");
+        _lblExpense.AddCssClass("denaro-expense");
         _chkExpense = Gtk.CheckButton.New();
         _chkExpense.SetActive(true);
         _chkExpense.AddCssClass("selection-mode");

--- a/NickvisionMoney.GNOME/Views/TransactionDialog.cs
+++ b/NickvisionMoney.GNOME/Views/TransactionDialog.cs
@@ -392,17 +392,17 @@ public partial class TransactionDialog
         if(_btnIncome.GetActive())
         {
             _btnIncome.AddCssClass("success");
-            _btnIncome.AddCssClass("money-income");
+            _btnIncome.AddCssClass("denaro-income");
             _btnExpense.RemoveCssClass("error");
-            _btnExpense.RemoveCssClass("money-expense");
+            _btnExpense.RemoveCssClass("denaro-expense");
         }
         else
         {
 
             _btnIncome.RemoveCssClass("success");
-            _btnIncome.RemoveCssClass("money-income");
+            _btnIncome.RemoveCssClass("denaro-income");
             _btnExpense.AddCssClass("error");
-            _btnExpense.AddCssClass("money-expense");
+            _btnExpense.AddCssClass("denaro-expense");
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -52,22 +52,29 @@ When you're done, create a pull request to the project.
 
 [![Please do not theme this app](https://stopthemingmy.app/badge.svg)](https://stopthemingmy.app) 
 
-The Linux version of this app is designed for GNOME and optimized for the default Adwaita theme. If you customized your system look, it can negatively affect Money. However, in case of a breakage, we provide a way to customize some elements using CSS so you can make it look as you need. The CSS code should be in `~/.var/app/org.nickvision.money/config/gtk-4.0/gtk.css` if you installed the app using Flatpak or in `~/.config/gtk-4.0/gtk.css` otherwise. An example:
+The Linux version of this app is designed for GNOME and optimized for the default Adwaita theme. If you customized your system look, it can negatively affect Money. However, in case of a breakage, we provide a way to customize some elements using CSS so you can make it look as you need. The CSS code should be added to `~/.config/gtk-4.0/gtk.css`. An example (not really pleasant-looking, it's just to show what modifications you can apply):
 
 ```
-.money-total {
+.denaro-total {
     background-color: @warning_color;
     color: #fff;
 }
 
-.money-income {
+.denaro-income {
     color: @purple_2;
 }
 
-.money-expense {
+.denaro-expense {
     background: linear-gradient(to right, #000, @blue_4);
     color: #fff;
 }
+
+@define-color denaro_calendar_today_bg_color @blue_5;
+@define-color denaro_calendar_today_fg_color #ff0000;
+@define-color denaro_calendar_marked_day_fg_color @success_color;
+@define-color denaro_calendar_selected_day_bg_color @card_bg_color;
+@define-color denaro_calendar_delected_day_fg_color #55cc10;
+@define-color denaro_calendar_other_month_fg_color @dark_5;
 ```
 
 # Dependencies


### PR DESCRIPTION
* CSS classes were renamed to have `denaro` prefix.
* Calendar widgets in app now use color variables. Default values are the same as before, but now it's possible to override colors using `@define-color`.
* README was changed to include new color variables. Also, now it's stated that CSS code should be added only to `~/.config/...`, because CSS override feature is probably only useful for Gradience users, and if Gradience theme is applied, CSS file in `~/.var/app/...` is ignored.

Screenshot of the app with Synthwave theme applied and the CSS code from README added:

![](https://i.imgur.com/fGW85hZ.png)

Closes #165 