### PR TITLE
GNOME - Translate desktop file and metainfo using strings from *.resx

### DIFF
--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -88,7 +88,7 @@ public partial class Program
         mainWindowController.AppInfo.ID = "org.nickvision.money";
         mainWindowController.AppInfo.Name = "Nickvision Money";
         mainWindowController.AppInfo.ShortName = "Money";
-        mainWindowController.AppInfo.Description = mainWindowController.Localizer["Description"];
+        mainWindowController.AppInfo.Description = $"{mainWindowController.Localizer["Description"]}.";
         mainWindowController.AppInfo.Version = "2023.1.0-beta3";
         mainWindowController.AppInfo.Changelog = "<ul><li>Money has been completely rewritten in C#. Money should now be a lot more stable and responsive. With the C# rewrite, there is now a new version of Money available on Windows!</li><li>Added an \"Ungrouped\" row to the groups section to allow filtering transactions that don't belong to a group</li><li>Added the ability to attach a jpg/pdf of a receipt to a transaction</li><li>Reworked the repeat transaction system and added support for a biweekly interval</li><li>Added the ability to hide the groups section</li><li>Made a group's description an optional field</li></ul>";
         mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionMoney");

--- a/NickvisionMoney.GNOME/install_extras.sh
+++ b/NickvisionMoney.GNOME/install_extras.sh
@@ -48,6 +48,9 @@ mkdir -p "${INSTALL_PREFIX}"/share/metainfo
 cp ./NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml    \
    "${INSTALL_PREFIX}"/share/metainfo/
 
+echo "Translating desktop file and metainfo..."
+python3 ./NickvisionMoney.GNOME/translate_meta.py ${INSTALL_PREFIX}
+
 echo "Installing mime types..."
 mkdir -p "${INSTALL_PREFIX}"/share/mime/packages
 cp ./NickvisionMoney.GNOME/org.nickvision.money.extension.xml   \

--- a/NickvisionMoney.GNOME/org.nickvision.money.desktop
+++ b/NickvisionMoney.GNOME/org.nickvision.money.desktop
@@ -2,15 +2,6 @@
 Version=1.0
 Name=Money
 Comment=A personal finance manager
-Comment[de]=Ein persönlicher Finanzmanager
-Comment[es]=Un gestor de finanzas personales
-Comment[fr]=Gestionnaire des dépenses personnelles
-Comment[hi]=एक व्यक्तिगत वित्त संयोजक
-Comment[hr]=Aplikacija za osobne financije
-Comment[it]=Gestione finanziaria personale
-Comment[ru]=Персональный менеджер финансов
-Comment[sv]=En personlig finanshanterare
-Comment[id]=Manajer keuangan pribadi
 Exec=/usr/opt/org.nickvision.money/NickvisionMoney.GNOME
 Icon=org.nickvision.money
 Terminal=false

--- a/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
+++ b/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
@@ -9,33 +9,6 @@
     <p>
       A personal finance manager
     </p>
-    <p xml:lang="de">
-      Ein persönlicher Finanzmanager
-    </p>
-	<p xml:lang="es">
-	  Un gestor de finanzas personales
-	</p>
-    <p xml:lang="fr">
-      Gestionnaire des dépenses personnelles
-    </p>
-    <p xml:lang="hr">
-      Aplikacija za osobne financije
-    </p>
-    <p xml:lang="hi">
-            एक व्यक्तिगत वित्त संयोजक
-    </p>
-    <p xml:lang="it">
-      Gestione finanziaria personale
-    </p>
-    <p xml:lang="ru">
-      Персональный менеджер финансов
-    </p>
-    <p xml:lang="sv">
-      En personlig finanshanterare
-    </p>
-    <p xml:lang="id">
-      Manajer keuangan pribadi
-    </p>
   </description>
   <launchable type="desktop-id">org.nickvision.money.desktop</launchable>
   <screenshots>

--- a/NickvisionMoney.GNOME/translate_meta.py
+++ b/NickvisionMoney.GNOME/translate_meta.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+script_dir = Path(__file__).parent
+resx_dir = (script_dir / '../NickvisionMoney.Shared/Resources/').resolve()
+install_prefix = sys.argv[1] if len(sys.argv) > 1 else '/usr'
+
+regex = re.compile(r'Strings\.(.+)\.resx')
+desktop_comments = []
+meta_descriptions = []
+for filename in os.listdir(resx_dir):
+    regex_match = regex.search(filename)
+    if regex_match:
+        lang_code = regex_match.group(1)
+        tree = ET.parse(f'{resx_dir}/{filename}')
+        root = tree.getroot()
+        for item in root.findall('./data'):
+            if item.attrib['name'] == 'MetaDescription.GTK':
+                text = item.find('value').text
+                if text:
+                    desktop_comments.append(f'Comment[{lang_code}]={text}')
+                    meta_descriptions.append(f'    <p xml:lang="{lang_code}">\n      {text}\n    </p>')
+desktop_comments.sort()
+meta_descriptions.sort()
+
+with open(f'{install_prefix}/share/applications/org.nickvision.money.desktop', 'r') as f:
+    contents = f.readlines()
+for i in range(len(contents)):
+    if contents[i].startswith('Comment='):
+        contents.insert(i + 1, "\n".join(desktop_comments) + "\n")
+        break
+with open(f'{install_prefix}/share/applications/org.nickvision.money.desktop', 'w') as f:
+    contents = "".join(contents)
+    f.write(contents)
+
+with open(f'{install_prefix}/share/metainfo/org.nickvision.money.metainfo.xml', 'r') as f:
+    contents = f.readlines()
+for i in range(len(contents)):
+    if contents[i].find('<description>') > -1:
+        contents.insert(i + 4, "\n".join(meta_descriptions) + "\n")
+        break
+with open(f'{install_prefix}/share/metainfo/org.nickvision.money.metainfo.xml', 'w') as f:
+    contents = "".join(contents)
+    f.write(contents)

--- a/NickvisionMoney.GNOME/translate_meta.py
+++ b/NickvisionMoney.GNOME/translate_meta.py
@@ -20,7 +20,7 @@ for filename in os.listdir(resx_dir):
         tree = ET.parse(f'{resx_dir}/{filename}')
         root = tree.getroot()
         for item in root.findall('./data'):
-            if item.attrib['name'] == 'MetaDescription.GTK':
+            if item.attrib['name'] == 'Description':
                 text = item.find('value').text
                 if text:
                     desktop_comments.append(f'Comment[{lang_code}]={text}')

--- a/NickvisionMoney.Shared/Resources/Strings.es.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.es.resx
@@ -14,7 +14,7 @@
   </resheader>
   <!--Use: &#xA; for newline-->
   <data name="Description" xml:space="preserve">
-		<value>Un gestor de finanzas personales.</value>
+		<value>Un gestor de finanzas personales</value>
   </data>
   <data name="Version" xml:space="preserve">
 		<value>Versión: {0}</value>
@@ -482,9 +482,6 @@ Cualquier cambio no guardado se perderá.</value>
   </data>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Cuenta bancaria (*.nmoney)</value>
-  </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value>Un gestor de finanzas personales</value>
   </data>
   <data name="NoEndDate" xml:space="preserve">
     <value>Sin fecha final</value>

--- a/NickvisionMoney.Shared/Resources/Strings.es.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.es.resx
@@ -483,4 +483,7 @@ Cualquier cambio no guardado se perderá.</value>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Cuenta bancaria (*.nmoney)</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value>Un gestor de finanzas personales</value>
+  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.fr.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.fr.resx
@@ -14,7 +14,7 @@
   </resheader>
   <!--Use: &#xA; for newline-->
   <data name="Description" xml:space="preserve">
-		<value>Un gestionnaire de finances personnelles.</value>
+		<value>Un gestionnaire de finances personnelles</value>
   </data>
   <data name="Version" xml:space="preserve">
 		<value>Version : {0}</value>
@@ -512,8 +512,5 @@ Cette action est irréversible.</value>
   </data>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Compte d’argent (*.nmoney)</value>
-  </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value>Gestionnaire des dépenses personnelles</value>
   </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.fr.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.fr.resx
@@ -513,4 +513,7 @@ Cette action est irréversible.</value>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Compte d’argent (*.nmoney)</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value>Gestionnaire des dépenses personnelles</value>
+  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.hi.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.hi.resx
@@ -512,4 +512,7 @@
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>मनी खाता (*.nmoney)</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value>एक व्यक्तिगत वित्त संयोजक</value>
+  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.hi.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.hi.resx
@@ -512,7 +512,4 @@
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>मनी खाता (*.nmoney)</value>
   </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value>एक व्यक्तिगत वित्त संयोजक</value>
-  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.hr.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.hr.resx
@@ -510,4 +510,7 @@
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value></value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value>Aplikacija za osobne financije</value>
+  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.hr.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.hr.resx
@@ -14,7 +14,7 @@
   </resheader>
   <!--Use: &#xA; for newline-->
   <data name="Description" xml:space="preserve">
-		<value></value>
+		<value>Aplikacija za osobne financije</value>
   </data>
   <data name="Version" xml:space="preserve">
 		<value></value>
@@ -509,8 +509,5 @@
   </data>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value></value>
-  </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value>Aplikacija za osobne financije</value>
   </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.id.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.id.resx
@@ -537,4 +537,7 @@ pekerjaan yang tidak disimpan akan hilang.</value>
   <data name="RepeatIntervalChanged" xml:space="preserve">
     <value>Interval Pengulangan diubah</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value>Manajer keuangan pribadi</value>
+  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.id.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.id.resx
@@ -14,7 +14,7 @@
   </resheader>
   <!--Use: &#xA; for newline-->
   <data name="Description" xml:space="preserve">
-		<value>Manajer keuangan pribadi.</value>
+		<value>Manajer keuangan pribadi</value>
   </data>
   <data name="Version" xml:space="preserve">
 		<value>Versi: {0}</value>
@@ -536,8 +536,5 @@ pekerjaan yang tidak disimpan akan hilang.</value>
   </data>
   <data name="RepeatIntervalChanged" xml:space="preserve">
     <value>Interval Pengulangan diubah</value>
-  </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value>Manajer keuangan pribadi</value>
   </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.it.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.it.resx
@@ -14,7 +14,7 @@
   </resheader>
   <!--Use: &#xA; for newline-->
   <data name="Description" xml:space="preserve">
-		<value>Gestione finanziaria personale.</value>
+		<value>Gestione finanziaria personale</value>
   </data>
   <data name="Version" xml:space="preserve">
 		<value>Versione {0}</value>
@@ -589,8 +589,5 @@ I cambiamenti non salvati saranno persi.</value>
   </data>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Account Money (*.nmoney)</value>
-  </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value>Gestione finanziaria personale</value>
   </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.it.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.it.resx
@@ -590,4 +590,7 @@ I cambiamenti non salvati saranno persi.</value>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Account Money (*.nmoney)</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value>Gestione finanziaria personale</value>
+  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.nl.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.nl.resx
@@ -525,10 +525,10 @@ Let op: niet-opgeslagen aanpassingen wordt gewist.</value>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Money-rekening (*.nmoney)</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value></value>
+  </data>
   <data name="Overview.Today" xml:space="preserve">
     <value>Dagoverzicht</value>
-  </data>
-  <data name="DeleteTransaction.SourceRepeat" xml:space="preserve">
-    <value>Transactie verwijderen</value>
   </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.nl.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.nl.resx
@@ -14,7 +14,7 @@
   </resheader>
   <!--Use: &#xA; for newline-->
   <data name="Description" xml:space="preserve">
-		<value>Een financiënbeheerder.</value>
+		<value>Een financiënbeheerder</value>
   </data>
   <data name="Version" xml:space="preserve">
 		<value>Versie: {0}</value>
@@ -524,9 +524,6 @@ Let op: niet-opgeslagen aanpassingen wordt gewist.</value>
   </data>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Money-rekening (*.nmoney)</value>
-  </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value></value>
   </data>
   <data name="Overview.Today" xml:space="preserve">
     <value>Dagoverzicht</value>

--- a/NickvisionMoney.Shared/Resources/Strings.nl.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.nl.resx
@@ -531,4 +531,7 @@ Let op: niet-opgeslagen aanpassingen wordt gewist.</value>
   <data name="Overview.Today" xml:space="preserve">
     <value>Dagoverzicht</value>
   </data>
+  <data name="DeleteTransaction.SourceRepeat" xml:space="preserve">
+    <value>Transactie verwijderen</value>
+  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -19,7 +19,7 @@
 	<!--Use: &#xA; for newline-->
 
 	<data name="Description" xml:space="preserve">
-		<value>A personal finance manager.</value>
+		<value>A personal finance manager</value>
 	</data>
 
 	<data name="Version" xml:space="preserve">
@@ -741,9 +741,5 @@
 
 	<data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Money Account (*.nmoney)</value>
-	</data>
-
-	<data name="MetaDescription.GTK" xml:space="preserve">
-		<value>A personal finance manager</value>
 	</data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -742,4 +742,8 @@
 	<data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Money Account (*.nmoney)</value>
 	</data>
+
+	<data name="MetaDescription.GTK" xml:space="preserve">
+		<value>A personal finance manager</value>
+	</data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.ru.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.ru.resx
@@ -14,7 +14,7 @@
   </resheader>
   <!--Use: &#xA; for newline-->
   <data name="Description" xml:space="preserve">
-		<value>Персональный менеджер финансов.</value>
+		<value>Персональный менеджер финансов</value>
   </data>
   <data name="Version" xml:space="preserve">
 		<value>Версия: {0}</value>
@@ -488,9 +488,6 @@
   </data>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Счёт Money (*.nmoney)</value>
-  </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-    <value>Персональный менеджер финансов</value>
   </data>
   <data name="GitHubRepo" xml:space="preserve">
     <value>Репозиторий GitHub</value>

--- a/NickvisionMoney.Shared/Resources/Strings.ru.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.ru.resx
@@ -489,6 +489,9 @@
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>Счёт Money (*.nmoney)</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+    <value>Персональный менеджер финансов</value>
+  </data>
   <data name="GitHubRepo" xml:space="preserve">
     <value>Репозиторий GitHub</value>
   </data>

--- a/NickvisionMoney.Shared/Resources/Strings.zh.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.zh.resx
@@ -489,7 +489,4 @@ Fyodor Sobolev https://github.com/fsobolev</value>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>軟體Money的帳戶 (*.nmoney)</value>
   </data>
-  <data name="MetaDescription.GTK" xml:space="preserve">
-		<value></value>
-  </data>
 </root>

--- a/NickvisionMoney.Shared/Resources/Strings.zh.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.zh.resx
@@ -489,4 +489,7 @@ Fyodor Sobolev https://github.com/fsobolev</value>
   <data name="AccountFileFilter.GTK" xml:space="preserve">
 		<value>軟體Money的帳戶 (*.nmoney)</value>
   </data>
+  <data name="MetaDescription.GTK" xml:space="preserve">
+		<value></value>
+  </data>
 </root>

--- a/NickvisionMoney.WinUI/App.xaml.cs
+++ b/NickvisionMoney.WinUI/App.xaml.cs
@@ -19,7 +19,7 @@ public partial class App : Application
         _mainWindowController.AppInfo.ID = "org.nickvision.money";
         _mainWindowController.AppInfo.Name = "Nickvision Money";
         _mainWindowController.AppInfo.ShortName = "Money";
-        _mainWindowController.AppInfo.Description = _mainWindowController.Localizer["Description"];
+        _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.1.0-beta3";
         _mainWindowController.AppInfo.Changelog = "- Money has been completely rewritten in C#. Money should now be a lot more stable and responsive.\nWith the C# rewrite, there is now a new version of Money available on Windows!\n- Added an \"Ungrouped\" row to the groups section to allow filtering transactions that don't belong to a group\n- Added the ability to attach a jpg/pdf of a receipt to a transaction\n- Reworked the repeat transaction system and added support for a biweekly interval\n- Added the ability to hide the groups section\n- Made a group's description an optional field";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionMoney");

--- a/README.md
+++ b/README.md
@@ -35,13 +35,7 @@ In the `NickvisionMoney.Shared/Resources` folder you will see a file called `Str
 
 To check your translation file, make sure your system is in the locale of the language you are translating and run the app. You should see your translated strings!
 
-Once all changes to your translated file are made, make sure the file is in the path `NickvisionMoney.Shared/Resources/String.<lang-code>.resx` and commit these changes.
-
-Even if you're running Windows, we ask you to also translate metadata for GNOME (Linux) version of the app. There are 2 places that require changes when a new translation is added:
-- `NickvisionMoney.GNOME/org.nickvision.money.desktop`: `Comment[lang-code]` line
-- `NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml`: `<description>` section
-
-When you're done, create a pull request to the project.
+Once all changes to your translated file are made, make sure the file is in the path `NickvisionMoney.Shared/Resources/String.<lang-code>.resx`, commit these changes and create a pull request to the project.
 
 # GNOME Screenshots
 ![GNOMELight](NickvisionMoney.GNOME/Screenshots/OpenAccount.png)


### PR DESCRIPTION
A new python script is added. It loops over `Strings.*.resx` files, gets translations for `MetaDescription.GTK` and adds new strings in proper formats to desktop and metainfo files. The script accepts install prefix as an argument, exactly like `install_extras.sh`, which calls this script now.
I copied strings from old desktop file to existing `Strings.*.resx`, and now after installation desktop and metainfo files have the following contents:

```
[Desktop Entry]
Version=1.0
Name=Money
Comment=A personal finance manager
Comment[es]=Un gestor de finanzas personales
Comment[fr]=Gestionnaire des dépenses personnelles
Comment[hi]=एक व्यक्तिगत वित्त संयोजक
Comment[hr]=Aplikacija za osobne financije
Comment[id]=Manajer keuangan pribadi
Comment[it]=Gestione finanziaria personale
Comment[ru]=Персональный менеджер финансов
Exec=/app/opt/org.nickvision.money/NickvisionMoney.GNOME
Icon=org.nickvision.money
Terminal=false
Type=Application
MimeType=application/x-nmoney
X-GNOME-UsesNotifications=true
X-Desktop-File-Install-Version=0.26
```

```
<?xml version="1.0" encoding="UTF-8"?>
<component type="desktop-application">
  <id>org.nickvision.money</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-3.0+</project_license>
  <name>Money</name>
  <summary>A personal finance manager</summary>
  <description>
    <p>
      A personal finance manager
    </p>
    <p xml:lang="es">
      Un gestor de finanzas personales
    </p>
    <p xml:lang="fr">
      Gestionnaire des dépenses personnelles
    </p>
    <p xml:lang="hi">
      एक व्यक्तिगत वित्त संयोजक
    </p>
    <p xml:lang="hr">
      Aplikacija za osobne financije
    </p>
    <p xml:lang="id">
      Manajer keuangan pribadi
    </p>
    <p xml:lang="it">
      Gestione finanziaria personale
    </p>
    <p xml:lang="ru">
      Персональный менеджер финансов
    </p>
  </description>
...
```