### PR TITLE
Shared - Add localizer fallback

### DIFF
--- a/NickvisionMoney.Shared/Helpers/Localizer.cs
+++ b/NickvisionMoney.Shared/Helpers/Localizer.cs
@@ -10,6 +10,7 @@ public class Localizer
 {
     private readonly ResourceManager _resourceManager;
     private readonly ResourceSet _resourceSet;
+    private readonly ResourceSet _resourceFallback;
 
     /// <summary>
     /// Gets a localized non-plural/plural string
@@ -33,6 +34,7 @@ public class Localizer
     {
         _resourceManager = new ResourceManager("NickvisionMoney.Shared.Resources.Strings", GetType().Assembly);
         _resourceSet = _resourceManager.GetResourceSet(CultureInfo.CurrentCulture, true, true)!;
+        _resourceFallback = _resourceManager.GetResourceSet(new CultureInfo("en-US"), true, true)!;
     }
 
     /// <summary>
@@ -40,7 +42,7 @@ public class Localizer
     /// </summary>
     /// <param name="name">The name of the string resource</param>
     /// <returns>The localized string</returns>
-    public string GetString(string name) => _resourceSet.GetString(name) ?? string.Empty;
+    public string GetString(string name) => _resourceSet.GetString(name) ?? _resourceFallback.GetString(name) ?? string.Empty;
 
     /// <summary>
     /// Gets a localized string by context
@@ -48,12 +50,12 @@ public class Localizer
     /// <param name="name">The name of the string resource</param>
     /// <param name="context">The name of the context</param>
     /// <returns>The localized string with the context</returns>
-    public string GetStringWithContext(string name, string context) => _resourceSet.GetString($"{name}.{context}") ?? string.Empty;
+    public string GetStringWithContext(string name, string context) => GetString($"{name}.{context}");
 
     /// <summary>
     /// Gets a localized plural string
     /// </summary>
     /// <param name="name">The name of the string resource</param>
     /// <returns>The localized plural string</returns>
-    public string GetPluralString(string name) => _resourceSet.GetString($"{name}.Plural") ?? string.Empty;
+    public string GetPluralString(string name) => GetString($"{name}.Plural");
 }


### PR DESCRIPTION
Currently if there are some untranslated strings in `*.resx`, nothing is shown in the UI because localizer returns `string.Empty`. This PR fixes it by adding fallback resource set to localizer that gets English strings, so the localizer returns them instead of empty strings.

You can see on the screenshot untranslated "Repeat End Date":

![](https://i.imgur.com/SfyWerr.png)