### PR TITLE
GNOME - Fix crash on linux-arm64

### DIFF
--- a/NickvisionMoney.GNOME/Controls/TransactionRow.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionRow.cs
@@ -82,8 +82,8 @@ public partial class TransactionRow : Adw.PreferencesGroup
         _row.SetSizeRequest(300, 70);
         var rowCssProvider = Gtk.CssProvider.New();
         var rowCss = @"row {
-            border-color: " + gdk_rgba_to_string(ref color) + "; }" + char.MinValue;
-        gtk_css_provider_load_from_data(rowCssProvider.Handle, rowCss, -1);
+            border-color: " + gdk_rgba_to_string(ref color) + "; }";
+        gtk_css_provider_load_from_data(rowCssProvider.Handle, rowCss, rowCss.Length);
         _row.GetStyleContext().AddProvider(rowCssProvider, GTK_STYLE_PROVIDER_PRIORITY_USER);
         //Button ID
         _btnId = Gtk.Button.New();
@@ -92,8 +92,8 @@ public partial class TransactionRow : Adw.PreferencesGroup
         _btnId.SetValign(Gtk.Align.Center);
         _btnId.SetLabel(_transaction.Id.ToString());
         var btnCssProvider = Gtk.CssProvider.New();
-        var btnCss = "#btnId { font-size: 14px; color: " + gdk_rgba_to_string(ref color) + "; }" + char.MinValue;
-        gtk_css_provider_load_from_data(btnCssProvider.Handle, btnCss, -1);
+        var btnCss = "#btnId { font-size: 14px; color: " + gdk_rgba_to_string(ref color) + "; }";
+        gtk_css_provider_load_from_data(btnCssProvider.Handle, btnCss, btnCss.Length);
         _btnId.GetStyleContext().AddProvider(btnCssProvider, GTK_STYLE_PROVIDER_PRIORITY_USER);
         _row.AddPrefix(_btnId);
         //Amount Label

--- a/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
+++ b/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
@@ -270,8 +270,8 @@ public partial class AccountSettingsDialog
         var bgColorStrArray = new Regex(@"[0-9]+,[0-9]+,[0-9]+").Match(bgColorString).Value.Split(",");
         var luma = int.Parse(bgColorStrArray[0]) / 255.0 * 0.2126 + int.Parse(bgColorStrArray[1]) / 255.0 * 0.7152 + int.Parse(bgColorStrArray[2]) / 255.0 * 0.0722;
         _btnAvatar.GetStyleContext().RemoveProvider(_btnAvatarCssProvider);
-        var btnCss = "#btnAvatar { color: " + (luma < 0.5 ? "#fff" : "#000") + "; background-color: " + bgColorString + "; }" + char.MinValue;
-        gtk_css_provider_load_from_data(_btnAvatarCssProvider.Handle, btnCss, -1);
+        var btnCss = "#btnAvatar { color: " + (luma < 0.5 ? "#fff" : "#000") + "; background-color: " + bgColorString + "; }";
+        gtk_css_provider_load_from_data(_btnAvatarCssProvider.Handle, btnCss, btnCss.Length);
         _btnAvatar.GetStyleContext().AddProvider(_btnAvatarCssProvider, 800);
     }
 

--- a/NickvisionMoney.GNOME/Views/MainWindow.cs
+++ b/NickvisionMoney.GNOME/Views/MainWindow.cs
@@ -571,8 +571,8 @@ public partial class MainWindow : Adw.ApplicationWindow
             var bgColorStrArray = new Regex(@"[0-9]+,[0-9]+,[0-9]+").Match(bgColorString).Value.Split(",");
             var luma = int.Parse(bgColorStrArray[0]) / 255.0 * 0.2126 + int.Parse(bgColorStrArray[1]) / 255.0 * 0.7152 + int.Parse(bgColorStrArray[2]) / 255.0 * 0.0722;
             var btnCssProvider = Gtk.CssProvider.New();
-            var btnCss = "#btnType { color: " + (luma < 0.5 ? "#fff" : "#000") + "; background-color: " + bgColorString + "; }" + char.MinValue;
-            gtk_css_provider_load_from_data(btnCssProvider.Handle, btnCss, -1);
+            var btnCss = "#btnType { color: " + (luma < 0.5 ? "#fff" : "#000") + "; background-color: " + bgColorString + "; }";
+            gtk_css_provider_load_from_data(btnCssProvider.Handle, btnCss, btnCss.Length);
             btnType.SetName("btnType");
             btnType.GetStyleContext().AddProvider(btnCssProvider, 800);
             row.AddSuffix(btnType);
@@ -583,8 +583,8 @@ public partial class MainWindow : Adw.ApplicationWindow
             var bgColorStrArray = new Regex(@"[0-9]+,[0-9]+,[0-9]+").Match(bgColorString).Value.Split(",");
             var luma = int.Parse(bgColorStrArray[0]) / 255.0 * 0.2126 + int.Parse(bgColorStrArray[1]) / 255.0 * 0.7152 + int.Parse(bgColorStrArray[2]) / 255.0 * 0.0722;
             var btnCssProvider = Gtk.CssProvider.New();
-            var btnCss = "#btnWallet { color: " + (luma < 0.5 ? "#fff" : "#000") + "; background-color: " + bgColorString + "; }" + char.MinValue;
-            gtk_css_provider_load_from_data(btnCssProvider.Handle, btnCss, -1);
+            var btnCss = "#btnWallet { color: " + (luma < 0.5 ? "#fff" : "#000") + "; background-color: " + bgColorString + "; }";
+            gtk_css_provider_load_from_data(btnCssProvider.Handle, btnCss, btnCss.Length);
             button.SetName("btnWallet");
             button.GetStyleContext().AddProvider(btnCssProvider, 800);
         }


### PR DESCRIPTION
After an account is created or opened, the app crashes with the following console output:

	Registering new type NickvisionMoneyGNOMEViewsMainWindow with parent AdwApplicationWindow

	(NickvisionMoney.GNOME:95889): Gtk-WARNING **: 01:51:07.063: Theme parser error: <data>:1:61-62: Expected a valid selector
	Segmentation fault (core dumped)

GDB backtrace shows it crashes on the gtk_css_provider_load_from_data function call:

	#43 0x0000ffbec8bdbbc0 in gtk_css_provider_load_from_data (css_provider=0xffbea80b8620,
	    data=0xffffdc9531d0 "#btnType { color: #fff; background-color: rgb(129,61,156); }", length=<optimized out>) at ../gtk/gtkcssprovider.c:1116
	#44 0x0000ffff74ad0af4 in ?? ()
	#45 0x0000ffffb7834360 in ?? () from /nix/store/h5l5d8xbx3prvzm51y6n5rvc5kajivcd-dotnet-runtime-7.0.0/shared/Microsoft.NETCore.App/7.0.0/libcoreclr.so
	Backtrace stopped: previous frame inner to this frame (corrupt stack?)

btnCss is 61 bytes long including the NUL terminator but it's reading the 62-nd byte. I don't know why this happens and why it doesn't happen on x86_64, but passing the length of btnCss fixes it.