### PR TITLE
Search By Description & Various Fixes

### DIFF
--- a/NickvisionMoney.GNOME/Controls/GroupRow.cs
+++ b/NickvisionMoney.GNOME/Controls/GroupRow.cs
@@ -75,7 +75,7 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
         _box.Append(_btnEdit);
         _box.Append(_btnDelete);
         AddSuffix(_box);
-        UpdateRow(group, filterActive);
+        UpdateRow(group, culture, filterActive);
     }
 
     /// <summary>
@@ -92,10 +92,12 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
     /// Updates the row with the new model
     /// </summary>
     /// <param name="group">The new Group model</param>
+    /// <param name="culture">The culture to use for displaying strings</param>
     /// <param name="filterActive">Whether or not the filter checkbox is active</param>
-    public void UpdateRow(Group group, bool filterActive)
+    public void UpdateRow(Group group, CultureInfo culture, bool filterActive)
     {
         Id = group.Id;
+        _culture = culture;
         //Row Settings
         SetTitle(group.Name);
         SetSubtitle(group.Description);

--- a/NickvisionMoney.GNOME/Controls/TransactionRow.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionRow.cs
@@ -112,7 +112,7 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
         _row.AddSuffix(_boxSuffix);
         //Group Settings
         Add(_row);
-        UpdateRow(transaction);
+        UpdateRow(transaction, culture);
     }
 
     /// <summary>
@@ -146,9 +146,11 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
     /// Updates the row with the new model
     /// </summary>
     /// <param name="transaction">The new Transaction model</param>
-    public void UpdateRow(Transaction transaction)
+    /// <param name="culture">The culture to use for displaying strings</param>
+    public void UpdateRow(Transaction transaction, CultureInfo culture)
     {
         Id = transaction.Id;
+        _culture = culture;
         //Color
         var color = new Color();
         if (!gdk_rgba_parse(ref color, transaction.RGBA))

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -58,7 +58,7 @@ public partial class Program
         _mainWindowController.AppInfo.ShortName = "Denaro";
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.2.0-next";
-        _mainWindowController .AppInfo.Changelog = "<ul><li></li></ul>";
+        _mainWindowController .AppInfo.Changelog = "<ul><li>Added the ability to search for transactions by description</li></ul>";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionMoney");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionMoney/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionMoney/discussions");

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -58,7 +58,7 @@ public partial class Program
         _mainWindowController.AppInfo.ShortName = "Denaro";
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.2.0-next";
-        _mainWindowController .AppInfo.Changelog = "<ul><li>Added the ability to search for transactions by description</li></ul>";
+        _mainWindowController .AppInfo.Changelog = "<ul><li>Added the ability to search for transactions by description</li><li>Fixed an issue where a change in an account's currency symbol would not display until account was reopened</li><li>Fixed an issue where a group row's filter checkbox resets on group update</li></ul>";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionMoney");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionMoney/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionMoney/discussions");

--- a/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
+++ b/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
@@ -158,7 +158,7 @@ public partial class AccountSettingsDialog
         _txtCustomCode.SetActivatesDefault(true);
         _txtCustomCode.OnNotify += (sender, e) =>
         {
-            if (e.Pspec.GetName() == "selected-item")
+            if (e.Pspec.GetName() == "text")
             {
                 if (!_constructing)
                 {

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -60,6 +60,7 @@ public partial class AccountView
     private readonly Adw.Flap _flap;
     private readonly Gtk.ScrolledWindow _scrollPane;
     private readonly Gtk.Box _paneBox;
+    private readonly Gtk.SearchEntry _txtSearchDescription;
     private readonly Gtk.Label _lblTotal;
     private readonly Adw.ActionRow _rowTotal;
     private readonly Gtk.Label _lblIncome;
@@ -159,6 +160,11 @@ public partial class AccountView
         _paneBox.SetMarginEnd(10);
         _paneBox.SetMarginBottom(10);
         _scrollPane.SetChild(_paneBox);
+        //Search Description Text
+        _txtSearchDescription = Gtk.SearchEntry.New();
+        _txtSearchDescription.SetProperty("placeholder-text", GObject.Value.From(_controller.Localizer["SearchDescription", "Placeholder"]));
+        _txtSearchDescription.OnSearchChanged += (sender, e) => _controller.SearchDescription = _txtSearchDescription.GetText();
+        _paneBox.Append(_txtSearchDescription);
         //Account Total
         _lblTotal = Gtk.Label.New("");
         _lblTotal.SetValign(Gtk.Align.Center);

--- a/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
+++ b/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
@@ -48,7 +48,9 @@
   <releases>
     <release version="2023.2.0-next" date="2023-1-17">
       <description>
-		<p>- Added the ability to search for transactions by description</p>
+		  <p>- Added the ability to search for transactions by description</p>
+		  <p>- Fixed an issue where a change in an account's currency symbol would not display until account was reopened</p>
+		  <p>- Fixed an issue where a group row's filter checkbox resets on group update</p>
       </description>
     </release>
   </releases>

--- a/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
+++ b/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
@@ -48,7 +48,7 @@
   <releases>
     <release version="2023.2.0-next" date="2023-1-17">
       <description>
-		<p></p>
+		<p>- Added the ability to search for transactions by description</p>
       </description>
     </release>
   </releases>

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -85,7 +85,7 @@ public class AccountViewController
     /// <summary>
     /// The total amount of the account for today as a string
     /// </summary>
-    public string AccountTodayTotalString => _account.TodayTotal.ToString("C", CultureForNumberString);
+    public string AccountTodayTotalString => $"{(_account.TodayTotal >= 0 ? "+ " : "- ")}{Math.Abs(_account.TodayTotal).ToString("C", CultureForNumberString)}";
     /// <summary>
     /// The income amount of the account for today
     /// </summary>

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -149,7 +149,7 @@ public class AccountViewController
         _filters.Add(-3, true); //Income 
         _filters.Add(-2, true); //Expense
         _filters.Add(-1, true); //No Group
-        foreach(var pair in _account.Groups)
+        foreach (var pair in _account.Groups)
         {
             _filters.Add((int)pair.Value.Id, true);
         }
@@ -336,6 +336,7 @@ public class AccountViewController
     public async Task StartupAsync()
     {
         await _account.SyncRepeatTransactionsAsync();
+        _searchDescription = "";
         //Groups
         GroupRows.Clear();
         foreach (var pair in _account.Groups.OrderBy(x => x.Value.Name == Localizer["Ungrouped"] ? " " : x.Value.Name))

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -19,6 +19,7 @@ public class AccountViewController
     private readonly Dictionary<int, bool> _filters;
     private DateOnly _filterStartDate;
     private DateOnly _filterEndDate;
+    private string _searchDescription;
 
     /// <summary>
     /// The localizer to get translated strings from
@@ -154,6 +155,7 @@ public class AccountViewController
         }
         _filterStartDate = DateOnly.FromDateTime(DateTime.Today);
         _filterEndDate = DateOnly.FromDateTime(DateTime.Today);
+        _searchDescription = "";
     }
 
     /// <summary>
@@ -276,6 +278,20 @@ public class AccountViewController
             }
             years.Sort();
             return years;
+        }
+    }
+
+    /// <summary>
+    /// The search description text
+    /// </summary>
+    public string SearchDescription
+    {
+        get => _searchDescription;
+
+        set
+        {
+            _searchDescription = value;
+            FilterUIUpdate();
         }
     }
 
@@ -783,6 +799,13 @@ public class AccountViewController
         var filteredTransactions = new List<uint>();
         foreach (var pair in _account.Transactions)
         {
+            if(!string.IsNullOrEmpty(SearchDescription))
+            {
+                if(!pair.Value.Description.Contains(SearchDescription))
+                {
+                    continue;
+                }
+            }
             if (pair.Value.Type == TransactionType.Income && !_filters[-3])
             {
                 continue;

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -801,7 +801,7 @@ public class AccountViewController
         {
             if(!string.IsNullOrEmpty(SearchDescription))
             {
-                if(!pair.Value.Description.Contains(SearchDescription))
+                if(!pair.Value.Description.ToLower().Contains(SearchDescription.ToLower()))
                 {
                     continue;
                 }

--- a/NickvisionMoney.Shared/Controls/IGroupRowControl.cs
+++ b/NickvisionMoney.Shared/Controls/IGroupRowControl.cs
@@ -1,5 +1,6 @@
 ﻿using NickvisionMoney.Shared.Models;
 using System;
+using System.Globalization;
 
 namespace NickvisionMoney.Shared.Controls;
 
@@ -22,12 +23,13 @@ public interface IGroupRowControl : IModelRowControl<Group>
     /// Updates the row based on the new Group model
     /// </summary>
     /// <param name="group">The new Group model</param>
-    void IModelRowControl<Group>.UpdateRow(Group group) => UpdateRow(group, true);
+    void IModelRowControl<Group>.UpdateRow(Group group, CultureInfo culture) => UpdateRow(group, culture, true);
 
     /// <summary>
     /// Updates the row based on the new Group model
     /// </summary>
     /// <param name="group">The new Group model</param>
+    /// <param name="culture">The culture to use for displaying strings</param>
     /// <param name="filterActive">Whether or not the filter checkbox is active</param>
-    public void UpdateRow(Group group, bool filterActive);
+    public void UpdateRow(Group group, CultureInfo culture, bool filterActive);
 }

--- a/NickvisionMoney.Shared/Controls/IModelRowControl.cs
+++ b/NickvisionMoney.Shared/Controls/IModelRowControl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace NickvisionMoney.Shared.Controls;
 
@@ -36,5 +37,6 @@ public interface IModelRowControl<T>
     /// Updates the row based on the new model
     /// </summary>
     /// <param name="newModel">The new model T</param>
-    public void UpdateRow(T newModel);
+    /// <param name="culture">The culture to use for displaying strings</param>
+    public void UpdateRow(T newModel, CultureInfo culture);
 }

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -436,6 +436,10 @@
 		<value>Sort By Date</value>
 	</data>
 
+	<data name="SearchDescription.Placeholder" xml:space="preserve">
+		<value>Search by description</value>
+	</data>
+
 	<!--AccountViewController-->
 	<data name="Ungrouped" xml:space="preserve">
 		<value>Ungrouped</value>

--- a/NickvisionMoney.WinUI/App.xaml.cs
+++ b/NickvisionMoney.WinUI/App.xaml.cs
@@ -27,7 +27,7 @@ public partial class App : Application
         _mainWindowController.AppInfo.ShortName = "Denaro";
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.2.0-next";
-        _mainWindowController.AppInfo.Changelog = "- Added the ability to search for transactions by description\n- Fixed an issue where a change in an account's currency symbol would not display until account was reopened\n- Fixed an issue where a group row's filter checkbox resets on group update";
+        _mainWindowController.AppInfo.Changelog = "- Added the ability to search for transactions by description\n- Fixed an issue where a change in an account's currency symbol would not display until account was reopened\n- Fixed an issue where a group row's filter checkbox resets on group update\n- Fixed an issue where transaction color changes were not applying";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionMoney");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionMoney/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionMoney/discussions");

--- a/NickvisionMoney.WinUI/App.xaml.cs
+++ b/NickvisionMoney.WinUI/App.xaml.cs
@@ -27,7 +27,7 @@ public partial class App : Application
         _mainWindowController.AppInfo.ShortName = "Denaro";
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.2.0-next";
-        _mainWindowController.AppInfo.Changelog = "";
+        _mainWindowController.AppInfo.Changelog = "- Added the ability to search for transactions by description";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionMoney");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionMoney/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionMoney/discussions");

--- a/NickvisionMoney.WinUI/App.xaml.cs
+++ b/NickvisionMoney.WinUI/App.xaml.cs
@@ -27,7 +27,7 @@ public partial class App : Application
         _mainWindowController.AppInfo.ShortName = "Denaro";
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.2.0-next";
-        _mainWindowController.AppInfo.Changelog = "- Added the ability to search for transactions by description";
+        _mainWindowController.AppInfo.Changelog = "- Added the ability to search for transactions by description\n- Fixed an issue where a change in an account's currency symbol would not display until account was reopened\n- Fixed an issue where a group row's filter checkbox resets on group update";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionMoney");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionMoney/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionMoney/discussions");

--- a/NickvisionMoney.WinUI/Controls/GroupRow.xaml.cs
+++ b/NickvisionMoney.WinUI/Controls/GroupRow.xaml.cs
@@ -95,7 +95,7 @@ public sealed partial class GroupRow : UserControl, IGroupRowControl
         LblName.Text = group.Name;
         LblDescription.Visibility = string.IsNullOrEmpty(group.Description) ? Visibility.Collapsed : Visibility.Visible;
         LblDescription.Text = group.Description;
-        LblAmount.Text = group.Balance.ToString("C", _culture);
+        LblAmount.Text = $"{(group.Balance >= 0 ? "+  " : "-  ")}{Math.Abs(group.Balance).ToString("C", _culture)}";
         LblAmount.Foreground = group.Balance >= 0 ? new SolidColorBrush(ActualTheme == ElementTheme.Light ? Color.FromArgb(255, 38, 162, 105) : Color.FromArgb(255, 143, 240, 164)) : new SolidColorBrush(ActualTheme == ElementTheme.Light ? Color.FromArgb(255, 192, 28, 40) : Color.FromArgb(255, 255, 123, 99));
     }
 

--- a/NickvisionMoney.WinUI/Controls/GroupRow.xaml.cs
+++ b/NickvisionMoney.WinUI/Controls/GroupRow.xaml.cs
@@ -51,7 +51,7 @@ public sealed partial class GroupRow : UserControl, IGroupRowControl
         MenuDelete.Text = localizer["Delete", "GroupRow"];
         ToolTipService.SetToolTip(BtnEdit, localizer["Edit", "GroupRow"]);
         ToolTipService.SetToolTip(BtnDelete, localizer["Delete", "GroupRow"]);
-        UpdateRow(group, filterActive);
+        UpdateRow(group, culture, filterActive);
     }
 
     /// <summary>
@@ -79,9 +79,11 @@ public sealed partial class GroupRow : UserControl, IGroupRowControl
     /// </summary>
     /// <param name="group">The new Group model</param>
     /// <param name="filterActive">Whether or not the filter checkbox is active</param>
-    public void UpdateRow(Group group, bool filterActive)
+    /// <param name="culture">The culture to use for displaying strings</param>
+    public void UpdateRow(Group group, CultureInfo culture, bool filterActive)
     {
         Id = group.Id;
+        _culture = culture;
         if(group.Id == 0)
         {
             MenuEdit.IsEnabled = false;

--- a/NickvisionMoney.WinUI/Controls/TransactionRow.xaml.cs
+++ b/NickvisionMoney.WinUI/Controls/TransactionRow.xaml.cs
@@ -58,7 +58,7 @@ public sealed partial class TransactionRow : UserControl, IModelRowControl<Trans
         MenuDelete.Text = _localizer["Delete", "TransactionRow"];
         ToolTipService.SetToolTip(BtnEdit, _localizer["Edit", "TransactionRow"]);
         ToolTipService.SetToolTip(BtnDelete, _localizer["Delete", "TransactionRow"]);
-        UpdateRow(transaction);
+        UpdateRow(transaction, culture);
     }
 
     /// <summary>
@@ -75,10 +75,12 @@ public sealed partial class TransactionRow : UserControl, IModelRowControl<Trans
     /// Updates the row with the new model
     /// </summary>
     /// <param name="transaction">The new Transaction model</param>
-    public void UpdateRow(Transaction transaction)
+    /// <param name="culture">The culture to use for displaying strings</param>
+    public void UpdateRow(Transaction transaction, CultureInfo culture)
     {
         Id = transaction.Id;
         _repeatFrom = transaction.RepeatFrom;
+        _culture = culture;
         MenuEdit.IsEnabled = _repeatFrom <= 0;
         BtnEdit.Visibility = _repeatFrom <= 0 ? Visibility.Visible : Visibility.Collapsed;
         MenuDelete.IsEnabled = _repeatFrom <= 0;

--- a/NickvisionMoney.WinUI/Views/AccountView.xaml
+++ b/NickvisionMoney.WinUI/Views/AccountView.xaml
@@ -131,8 +131,10 @@
 
         <wct:DockPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="6,46,6,6" LastChildFill="True">
             <ScrollViewer x:Name="ScrollSidebar" wct:DockPanel.Dock="Left" Width="340" VerticalScrollBarVisibility="Auto">
-                <wct:DockPanel LastChildFill="True">
-                    <Border wct:DockPanel.Dock="Top" Height="160" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" CornerRadius="8">
+                <wct:DockPanel LastChildFill="True" Margin="0,0,10,0">
+                    <AutoSuggestBox x:Name="TxtSearchDescription" wct:DockPanel.Dock="Top" QueryIcon="Find" TextChanged="TxtSearchDescription_TextChanged"/>
+
+                    <Border wct:DockPanel.Dock="Top" Margin="0,6,0,0" Height="160" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" CornerRadius="8">
                         <StackPanel Spacing="12">
                             <TextBlock x:Name="LblOverview" Margin="10,6,0,0" Style="{ThemeResource NavigationViewItemHeaderTextStyle}"/>
 
@@ -198,7 +200,7 @@
                 </wct:DockPanel>
             </ScrollViewer>
 
-            <nickvision:ViewStack x:Name="ViewStackTransactions" wct:DockPanel.Dock="Right" Margin="0,-6,0,0">
+            <nickvision:ViewStack x:Name="ViewStackTransactions" wct:DockPanel.Dock="Right" Margin="-4,-6,0,0">
                 <nickvision:ViewStack.Pages>
                     <nickvision:ViewStackPage PageName="NoTransactions">
                         <nickvision:StatusPage x:Name="StatusPageNoTransactions" HorizontalAlignment="Center" VerticalAlignment="Center"/>

--- a/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
@@ -59,6 +59,7 @@ public sealed partial class AccountView : UserControl
         MenuResetGroupsFilters.Text = _controller.Localizer["ResetFilters", "Groups"];
         MenuResetDatesFilters.Text = _controller.Localizer["ResetFilters", "Dates"];
         BtnAccountSettings.Label = _controller.Localizer["AccountSettings"];
+        TxtSearchDescription.PlaceholderText = _controller.Localizer["SearchDescription", "Placeholder"];
         LblOverview.Text = _controller.Localizer["Overview", "Today"];
         LblTotalTitle.Text = $"{_controller.Localizer["Total"]}:";
         LblIncomeTitle.Text = $"{_controller.Localizer["Income"]}:";
@@ -746,6 +747,13 @@ public sealed partial class AccountView : UserControl
             _controller.UpdateMetadata(accountSettingsController.Metadata);
         }
     }
+
+    /// <summary>
+    /// Occurs when the search description textbox is changed
+    /// </summary>
+    /// <param name="sender">AutoSuggestBox</param>
+    /// <param name="args">AutoSuggestBoxTextChangedEventArgs</param>
+    private void TxtSearchDescription_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args) => _controller.SearchDescription = TxtSearchDescription.Text;
 
     /// <summary>
     /// Occurs when the income filter checkbox is changed

--- a/NickvisionMoney.WinUI/Views/TransactionDialog.xaml
+++ b/NickvisionMoney.WinUI/Views/TransactionDialog.xaml
@@ -59,7 +59,7 @@
             <StackPanel HorizontalAlignment="Stretch" Spacing="6">
                 <TextBlock x:Name="LblColor"/>
 
-                <wct:ColorPickerButton x:Name="BtnColor" HorizontalAlignment="Stretch" Margin="0,2,0,0" Height="32" />
+                <wct:ColorPickerButton x:Name="BtnColor" HorizontalAlignment="Stretch" Margin="0,2,0,0" Height="32" SelectedColor="{x:Bind SelectedColor, Mode=TwoWay}"/>
             </StackPanel>
 
             <StackPanel HorizontalAlignment="Stretch" Spacing="6">

--- a/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class TransactionDialog : ContentDialog
     private bool _constructing;
     private readonly TransactionDialogController _controller;
     private readonly Action<object> _initializeWithWindow;
+    private Color _selectedColor;
     private string? _receiptPath;
 
     /// <summary>
@@ -87,11 +88,25 @@ public sealed partial class TransactionDialog : ContentDialog
         {
             CalendarRepeatEndDate.Date = new DateTimeOffset(new DateTime(_controller.Transaction.RepeatEndDate.Value.Year, _controller.Transaction.RepeatEndDate.Value.Month, _controller.Transaction.RepeatEndDate.Value.Day));
         }
-        BtnColor.SelectedColor = (Color)ColorHelpers.FromRGBA(_controller.Transaction.RGBA)!;
+        _selectedColor = (Color)ColorHelpers.FromRGBA(_controller.Transaction.RGBA)!;
         BtnReceiptView.IsEnabled = _controller.Transaction.Receipt != null;
         BtnReceiptDelete.IsEnabled = _controller.Transaction.Receipt != null;
         Validate();
         _constructing = false;
+    }
+
+    public Color SelectedColor
+    {
+        get => _selectedColor;
+
+        set
+        {
+            _selectedColor = value;
+            if(!_constructing)
+            {
+                Validate();
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This PR adds the ability to search for transactions via their description.
This PR also includes some fixes for applying custom currency in account settings and group filters.
This PR also fixes an issue where a transaction color change was not applied in WinUI.

# Search By Description
## GNOME
### Account Open
![image](https://user-images.githubusercontent.com/17648453/213065973-5af95333-9482-4359-9842-8d03f5da5494.png)
### Search
![image](https://user-images.githubusercontent.com/17648453/213066067-7ec7f901-4b73-44c7-b5e9-4b7e5f902255.png)
## WinUI
### Account Open
![image](https://user-images.githubusercontent.com/17648453/213066349-12299508-27cc-4a7d-af35-23fc9605e0a9.png)
### Search
![image](https://user-images.githubusercontent.com/17648453/213066371-d57a0d5a-9209-4a44-8590-ef416273d8c6.png)

Closes #203 
Closes #225 
Closes #226
Closes #227 