### PR TITLE
Add Help button to toast notification when no transactions are imported

### DIFF
--- a/NickvisionMoney.GNOME/Views/MainWindow.cs
+++ b/NickvisionMoney.GNOME/Views/MainWindow.cs
@@ -332,7 +332,16 @@ public partial class MainWindow : Adw.ApplicationWindow
     /// </summary>
     /// <param name="sender">object?</param>
     /// <param name="e">NotificationSentEventArgs</param>
-    private void NotificationSent(object? sender, NotificationSentEventArgs e) => _toastOverlay.AddToast(Adw.Toast.New(e.Message));
+    private void NotificationSent(object? sender, NotificationSentEventArgs e)
+    {
+        var toast = Adw.Toast.New(e.Message);
+        if (e.Action == "help-import")
+        {
+            toast.SetButtonLabel(_controller.Localizer["Help"]);
+            toast.OnButtonClicked += (sender, e) => gtk_show_uri(Handle, "help:denaro/import-export", 0);
+        }
+        _toastOverlay.AddToast(toast);
+    }
 
     /// <summary>
     /// Updates the window's subtitle

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -820,7 +820,7 @@ public class AccountViewController
         }
         else
         {
-            NotificationSent?.Invoke(this, new NotificationSentEventArgs(Localizer["UnableToImport"], NotificationSeverity.Error));
+            NotificationSent?.Invoke(this, new NotificationSentEventArgs(Localizer["UnableToImport"], NotificationSeverity.Error, "help-import"));
         }
     }
 

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -816,7 +816,7 @@ public class AccountViewController
                 GroupRows[groupId].UpdateRow(_account.Groups[groupId], CultureForNumberString, CultureForDateString, _filters[(int)groupId]);
             }    
             FilterUIUpdate();
-            NotificationSent?.Invoke(this, new NotificationSentEventArgs(importedIds.Count == 1 ? string.Format(Localizer["Imported"], importedIds.Count) : string.Format(Localizer["Imported", true], importedIds.Count), NotificationSeverity.Success));
+            NotificationSent?.Invoke(this, new NotificationSentEventArgs(importedIds.Count == 1 ? string.Format(Localizer["Imported"], importedIds.Count) : string.Format(Localizer["Imported", true], importedIds.Count), NotificationSeverity.Success, importedIds.Count == 0 ? "help-import" : ""));
         }
         else
         {

--- a/NickvisionMoney.Shared/Events/NotificationSentEventArgs.cs
+++ b/NickvisionMoney.Shared/Events/NotificationSentEventArgs.cs
@@ -25,6 +25,7 @@ public class NotificationSentEventArgs : EventArgs
     /// </summary>
     /// <param name="message">The message of the notification</param>
     /// <param name="severity">The severity of the notification</param>
+    /// <param name="action">Additional action for notification</param>
     public NotificationSentEventArgs(string message, NotificationSeverity severity, string action = "")
     {
         Message = message;

--- a/NickvisionMoney.Shared/Events/NotificationSentEventArgs.cs
+++ b/NickvisionMoney.Shared/Events/NotificationSentEventArgs.cs
@@ -15,15 +15,20 @@ public class NotificationSentEventArgs : EventArgs
     /// The severity of the notification
     /// </summary>
     public NotificationSeverity Severity { get; set; }
+    /// <summary>
+    /// Additional action for notification
+    /// </summary>
+    public string Action { get; set; }
 
     /// <summary>
     /// Constructs a NotificationSentEventArgs
     /// </summary>
     /// <param name="message">The message of the notification</param>
     /// <param name="severity">The severity of the notification</param>
-    public NotificationSentEventArgs(string message, NotificationSeverity severity)
+    public NotificationSentEventArgs(string message, NotificationSeverity severity, string action = "")
     {
         Message = message;
         Severity = severity;
+        Action = action;
     }
 }

--- a/NickvisionMoney.WinUI/Views/MainWindow.xaml
+++ b/NickvisionMoney.WinUI/Views/MainWindow.xaml
@@ -112,7 +112,11 @@
                     </nickvision:ViewStack.Pages>
                 </nickvision:ViewStack>
 
-                <InfoBar x:Name="InfoBar" HorizontalAlignment="Center" VerticalAlignment="Bottom" CornerRadius="12" Margin="0,0,0,10"/>
+                <InfoBar x:Name="InfoBar" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,10" CornerRadius="12">
+                    <InfoBar.ActionButton>
+                        <Button x:Name="BtnInfoBar" HorizontalAlignment="Right"/>
+                    </InfoBar.ActionButton>
+                </InfoBar>
             </Grid>
         </NavigationView>
     </Grid>

--- a/NickvisionMoney.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/MainWindow.xaml.cs
@@ -12,13 +12,16 @@ using NickvisionMoney.WinUI.Controls;
 using NickvisionMoney.WinUI.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Vanara.PInvoke;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics;
 using Windows.Storage;
 using Windows.Storage.Pickers;
+using Windows.System;
 using Windows.UI;
 using WinRT;
 using WinRT.Interop;
@@ -37,6 +40,7 @@ public sealed partial class MainWindow : Window
     private readonly SystemBackdropConfiguration _backdropConfiguration;
     private readonly MicaController? _micaController;
     private readonly Dictionary<string, AccountView> _accountViews;
+    private RoutedEventHandler? _notificationButtonClickEvent;
 
     /// <summary>
     /// Constructs a MainWindow
@@ -250,6 +254,26 @@ public sealed partial class MainWindow : Window
             NotificationSeverity.Error => InfoBarSeverity.Error,
             _ => InfoBarSeverity.Informational
         };
+        if(_notificationButtonClickEvent != null)
+        {
+            BtnInfoBar.Click -= _notificationButtonClickEvent;
+        }
+        BtnInfoBar.Visibility = !string.IsNullOrEmpty(e.Action) ? Visibility.Visible : Visibility.Collapsed;
+        if(e.Action == "help-import")
+        {
+            BtnInfoBar.Content = _controller.Localizer["Help"];
+            _notificationButtonClickEvent = async (sender, e) =>
+            {
+                var lang = "C";
+                var availableTranslations = new string[2] { "es", "ru" };
+                if (availableTranslations.Contains(CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
+                {
+                    lang = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+                }
+                await Launcher.LaunchUriAsync(new Uri($"https://htmlpreview.github.io/?https://raw.githubusercontent.com/nlogozzo/NickvisionMoney/{_controller.AppInfo.Version}/NickvisionMoney.Shared/Docs/html/{lang}/import-export.html"));
+            };
+            BtnInfoBar.Click += _notificationButtonClickEvent;
+        }
         InfoBar.IsOpen = true;
     }
 


### PR DESCRIPTION
Button is only shown when no transactions are imported (0 or "Unable to import..."). When clicked, "Import-Export" page in Yelp gets opened.

![](https://i.imgur.com/y57Jrxt.png)