### PR TITLE
GNOME - Add developer name to app metadata

### DIFF
--- a/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
+++ b/NickvisionMoney.GNOME/org.nickvision.money.metainfo.xml
@@ -4,6 +4,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Denaro</name>
+  <developer_name>Nickvision</developer_name>
   <summary>Manage your personal finances</summary>
   <description>
     <p>


### PR DESCRIPTION
Small issue I noticed within Flatseal (`Unknown` developer)

![image](https://user-images.githubusercontent.com/8540562/216854823-6c26943b-62a9-4587-888f-2ada245104c3.png)

https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer_name