### PR TITLE
GNOME - Improve styling of amount labels

### DIFF
--- a/NickvisionMoney.GNOME/Controls/GroupRow.cs
+++ b/NickvisionMoney.GNOME/Controls/GroupRow.cs
@@ -111,7 +111,6 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
         _chkFilter.SetActive(filterActive);
         //Amount Label
         _lblAmount.SetLabel($"{(group.Balance >= 0 ? "+  " : "-  ")}{Math.Abs(group.Balance).ToString("C", _cultureAmount)}");
-        _lblAmount.AddCssClass(group.Balance >= 0 ? "success" : "error");
         _lblAmount.AddCssClass(group.Balance >= 0 ? "denaro-income" : "denaro-expense");
         //Buttons
         _btnEdit.SetVisible(group.Id != 0);

--- a/NickvisionMoney.GNOME/Controls/GroupRow.cs
+++ b/NickvisionMoney.GNOME/Controls/GroupRow.cs
@@ -14,7 +14,6 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
     private CultureInfo _cultureAmount;
     private CultureInfo _cultureDate;
     private readonly Gtk.CheckButton _chkFilter;
-    private readonly Gtk.Button _btnAmount;
     private readonly Gtk.Label _lblAmount;
     private readonly Gtk.Button _btnEdit;
     private readonly Gtk.Button _btnDelete;
@@ -58,17 +57,9 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
         _chkFilter.AddCssClass("selection-mode");
         _chkFilter.OnToggled += FilterToggled;
         AddPrefix(_chkFilter);
-        //Amount
-        _btnAmount = Gtk.Button.New();
-        _btnAmount.AddCssClass("circular");
-        _btnAmount.SetHalign(Gtk.Align.End);
-        _btnAmount.SetValign(Gtk.Align.Center);
-        _btnAmount.SetMarginEnd(4);
-        _btnAmount.OnClicked += (sender, e) => Activate();
+        //Amount Label
         _lblAmount = Gtk.Label.New(null);
-        _lblAmount.SetMarginStart(12);
-        _lblAmount.SetMarginEnd(12);
-        _btnAmount.SetChild(_lblAmount);
+        _lblAmount.SetValign(Gtk.Align.Center);
         //Edit Button
         _btnEdit = Gtk.Button.NewFromIconName("document-edit-symbolic");
         _btnEdit.SetValign(Gtk.Align.Center);
@@ -84,7 +75,7 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
         _btnDelete.OnClicked += Delete;
         //Box
         _box = Gtk.Box.New(Gtk.Orientation.Horizontal, 6);
-        _box.Append(_btnAmount);
+        _box.Append(_lblAmount);
         _box.Append(_btnEdit);
         _box.Append(_btnDelete);
         AddSuffix(_box);

--- a/NickvisionMoney.GNOME/Controls/TransactionRow.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionRow.cs
@@ -79,6 +79,7 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
         _row = Adw.ActionRow.New();
         _row.SetUseMarkup(false);
         _row.SetTitleLines(1);
+        _row.SetSubtitleLines(1);
         _row.SetSizeRequest(300, 78);
         //Button ID
         _btnId = Gtk.Button.New();
@@ -93,7 +94,7 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
         _lblAmount = Gtk.Label.New(null);
         _lblAmount.SetHalign(Gtk.Align.End);
         _lblAmount.SetValign(Gtk.Align.Center);
-        _lblAmount.SetMarginEnd(5);
+        _lblAmount.SetMarginEnd(6);
         //Edit Button
         _btnEdit = Gtk.Button.NewFromIconName("document-edit-symbolic");
         _btnEdit.SetValign(Gtk.Align.Center);

--- a/NickvisionMoney.GNOME/Controls/TransactionRow.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionRow.cs
@@ -185,7 +185,6 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
         _iconCompact.GetStyleContext().AddProvider(btnCssProvider, GTK_STYLE_PROVIDER_PRIORITY_USER);
         //Amount Label
         _lblAmount.SetLabel($"{(transaction.Type == TransactionType.Income ? "+  " : "-  ")}{transaction.Amount.ToString("C", _cultureAmount)}");
-        _lblAmount.AddCssClass(transaction.Type == TransactionType.Income ? "success" : "error");
         _lblAmount.AddCssClass(transaction.Type == TransactionType.Income ? "denaro-income" : "denaro-expense");
         //Buttons Box
         _btnEdit.SetVisible(transaction.RepeatFrom <= 0);

--- a/NickvisionMoney.GNOME/Controls/TransactionRow.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionRow.cs
@@ -40,7 +40,6 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
     private readonly Adw.ActionRow _row;
     private readonly Gtk.Button _btnId;
     private readonly Gtk.Image _iconCompact;
-    private readonly Gtk.Button _btnAmount;
     private readonly Gtk.Label _lblAmount;
     private readonly Gtk.Button _btnEdit;
     private readonly Gtk.Button _btnDelete;
@@ -90,17 +89,11 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
         _iconCompact.SetName("iconCompact");
         _row.AddPrefix(_btnId);
         _row.AddPrefix(_iconCompact);
-        //Amount
-        _btnAmount = Gtk.Button.New();
-        _btnAmount.AddCssClass("circular");
-        _btnAmount.SetHalign(Gtk.Align.End);
-        _btnAmount.SetValign(Gtk.Align.Center);
-        _btnAmount.SetMarginEnd(4);
-        _btnAmount.OnClicked += (sender, e) => _row.Activate();
+        //Amount Label
         _lblAmount = Gtk.Label.New(null);
-        _lblAmount.SetMarginStart(12);
-        _lblAmount.SetMarginEnd(12);
-        _btnAmount.SetChild(_lblAmount);
+        _lblAmount.SetHalign(Gtk.Align.End);
+        _lblAmount.SetValign(Gtk.Align.Center);
+        _lblAmount.SetMarginEnd(5);
         //Edit Button
         _btnEdit = Gtk.Button.NewFromIconName("document-edit-symbolic");
         _btnEdit.SetValign(Gtk.Align.Center);
@@ -117,13 +110,12 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
         //Buttons Box
         _boxButtons = Gtk.Box.New(Gtk.Orientation.Horizontal, 6);
         _boxButtons.SetHalign(Gtk.Align.End);
-        _boxButtons.SetMarginEnd(4);
         _boxButtons.Append(_btnEdit);
         _boxButtons.Append(_btnDelete);
         //Suffix Box
         _boxSuffix = Gtk.Box.New(Gtk.Orientation.Horizontal, 2);
         _boxSuffix.SetValign(Gtk.Align.Center);
-        _boxSuffix.Append(_btnAmount);
+        _boxSuffix.Append(_lblAmount);
         _boxSuffix.Append(_boxButtons);
         _row.AddSuffix(_boxSuffix);
         //Group Settings

--- a/NickvisionMoney.GNOME/Resources/org.nickvision.money-dark.css
+++ b/NickvisionMoney.GNOME/Resources/org.nickvision.money-dark.css
@@ -1,0 +1,11 @@
+.denaro-total {
+  color: @blue_1;
+}
+
+.denaro-income {
+  color: @green_1;
+}
+
+.denaro-expense {
+  color: @red_1;
+}

--- a/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
+++ b/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
@@ -1,3 +1,15 @@
+.denaro-total {
+  color: @blue_4;
+}
+
+.denaro-income {
+  color: @green_4;
+}
+
+.denaro-expense {
+  color: @red_4;
+}
+
 .wallet-button {
   background-color: #00000000;
 }

--- a/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
+++ b/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
@@ -1,13 +1,16 @@
 .denaro-total {
-  color: @blue_4;
+  color: @blue_5;
+  font-weight: bold;
 }
 
 .denaro-income {
-  color: @green_4;
+  color: @green_5;
+  font-weight: bold;
 }
 
 .denaro-expense {
-  color: @red_4;
+  color: @red_5;
+  font-weight: bold;
 }
 
 .wallet-button {

--- a/NickvisionMoney.GNOME/Resources/org.nickvision.money.gresource.xml
+++ b/NickvisionMoney.GNOME/Resources/org.nickvision.money.gresource.xml
@@ -2,5 +2,6 @@
 <gresources>
   <gresource prefix="/org/nickvision/money">
     <file alias="style.css">NickvisionMoney.GNOME/Resources/org.nickvision.money.css</file>
+    <file alias="style-dark.css">NickvisionMoney.GNOME/Resources/org.nickvision.money-dark.css</file>
   </gresource>
 </gresources>

--- a/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
+++ b/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
@@ -420,17 +420,12 @@ public partial class AccountSettingsDialog
     {
         if (_btnIncome.GetActive())
         {
-            _btnIncome.AddCssClass("success");
             _btnIncome.AddCssClass("denaro-income");
-            _btnExpense.RemoveCssClass("error");
             _btnExpense.RemoveCssClass("denaro-expense");
         }
         else
         {
-
-            _btnIncome.RemoveCssClass("success");
             _btnIncome.RemoveCssClass("denaro-income");
-            _btnExpense.AddCssClass("error");
             _btnExpense.AddCssClass("denaro-expense");
         }
         if (!_constructing)

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -170,7 +170,6 @@ public partial class AccountView
         //Account Total
         _lblTotal = Gtk.Label.New("");
         _lblTotal.SetValign(Gtk.Align.Center);
-        _lblTotal.AddCssClass("accent");
         _lblTotal.AddCssClass("denaro-total");
         _rowTotal = Adw.ActionRow.New();
         _rowTotal.SetTitle(_controller.Localizer["Total"]);
@@ -178,8 +177,7 @@ public partial class AccountView
         //Account Income
         _lblIncome = Gtk.Label.New("");
         _lblIncome.SetValign(Gtk.Align.Center);
-        _lblIncome.AddCssClass("success");
-        _lblTotal.AddCssClass("denaro-income");
+        _lblIncome.AddCssClass("denaro-income");
         _chkIncome = Gtk.CheckButton.New();
         _chkIncome.SetActive(true);
         _chkIncome.AddCssClass("selection-mode");
@@ -192,7 +190,6 @@ public partial class AccountView
         //Account Expense
         _lblExpense = Gtk.Label.New("");
         _lblExpense.SetValign(Gtk.Align.Center);
-        _lblExpense.AddCssClass("error");
         _lblExpense.AddCssClass("denaro-expense");
         _chkExpense = Gtk.CheckButton.New();
         _chkExpense.SetActive(true);

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -61,14 +61,11 @@ public partial class AccountView
     private readonly Gtk.ScrolledWindow _scrollPane;
     private readonly Gtk.Box _paneBox;
     private readonly Gtk.SearchEntry _txtSearchDescription;
-    private readonly Gtk.Button _btnTotal;
     private readonly Gtk.Label _lblTotal;
     private readonly Adw.ActionRow _rowTotal;
-    private readonly Gtk.Button _btnIncome;
     private readonly Gtk.Label _lblIncome;
     private readonly Gtk.CheckButton _chkIncome;
     private readonly Adw.ActionRow _rowIncome;
-    private readonly Gtk.Button _btnExpense;
     private readonly Gtk.Label _lblExpense;
     private readonly Gtk.CheckButton _chkExpense;
     private readonly Adw.ActionRow _rowExpense;
@@ -171,30 +168,18 @@ public partial class AccountView
         _txtSearchDescription.OnSearchChanged += (sender, e) => _controller.SearchDescription = _txtSearchDescription.GetText();
         _paneBox.Append(_txtSearchDescription);
         //Account Total
-        _btnTotal = Gtk.Button.New();
-        _btnTotal.AddCssClass("circular");
-        _btnTotal.SetHalign(Gtk.Align.End);
-        _btnTotal.SetValign(Gtk.Align.Center);
         _lblTotal = Gtk.Label.New("");
+        _lblTotal.SetValign(Gtk.Align.Center);
         _lblTotal.AddCssClass("accent");
         _lblTotal.AddCssClass("denaro-total");
-        _lblTotal.SetMarginStart(12);
-        _lblTotal.SetMarginEnd(12);
-        _btnTotal.SetChild(_lblTotal);
         _rowTotal = Adw.ActionRow.New();
         _rowTotal.SetTitle(_controller.Localizer["Total"]);
-        _rowTotal.AddSuffix(_btnTotal);
+        _rowTotal.AddSuffix(_lblTotal);
         //Account Income
-        _btnIncome = Gtk.Button.New();
-        _btnIncome.AddCssClass("circular");
-        _btnIncome.SetHalign(Gtk.Align.End);
-        _btnIncome.SetValign(Gtk.Align.Center);
         _lblIncome = Gtk.Label.New("");
+        _lblIncome.SetValign(Gtk.Align.Center);
         _lblIncome.AddCssClass("success");
-        _lblIncome.AddCssClass("denaro-income");
-        _lblIncome.SetMarginStart(12);
-        _lblIncome.SetMarginEnd(12);
-        _btnIncome.SetChild(_lblIncome);
+        _lblTotal.AddCssClass("denaro-income");
         _chkIncome = Gtk.CheckButton.New();
         _chkIncome.SetActive(true);
         _chkIncome.AddCssClass("selection-mode");
@@ -203,18 +188,12 @@ public partial class AccountView
         _rowIncome = Adw.ActionRow.New();
         _rowIncome.SetTitle(_controller.Localizer["Income"]);
         _rowIncome.AddPrefix(_chkIncome);
-        _rowIncome.AddSuffix(_btnIncome);
+        _rowIncome.AddSuffix(_lblIncome);
         //Account Expense
-        _btnExpense = Gtk.Button.New();
-        _btnExpense.AddCssClass("circular");
-        _btnExpense.SetHalign(Gtk.Align.End);
-        _btnExpense.SetValign(Gtk.Align.Center);
         _lblExpense = Gtk.Label.New("");
+        _lblExpense.SetValign(Gtk.Align.Center);
         _lblExpense.AddCssClass("error");
         _lblExpense.AddCssClass("denaro-expense");
-        _lblExpense.SetMarginStart(12);
-        _lblExpense.SetMarginEnd(12);
-        _btnExpense.SetChild(_lblExpense);
         _chkExpense = Gtk.CheckButton.New();
         _chkExpense.SetActive(true);
         _chkExpense.AddCssClass("selection-mode");
@@ -223,7 +202,7 @@ public partial class AccountView
         _rowExpense = Adw.ActionRow.New();
         _rowExpense.SetTitle(_controller.Localizer["Expense"]);
         _rowExpense.AddPrefix(_chkExpense);
-        _rowExpense.AddSuffix(_btnExpense);
+        _rowExpense.AddSuffix(_lblExpense);
         //Overview Buttons Box
         _boxButtonsOverview = Gtk.Box.New(Gtk.Orientation.Horizontal, 6);
         //Button Menu Account Actions

--- a/NickvisionMoney.GNOME/Views/TransactionDialog.cs
+++ b/NickvisionMoney.GNOME/Views/TransactionDialog.cs
@@ -461,17 +461,12 @@ public partial class TransactionDialog
     {
         if (_btnIncome.GetActive())
         {
-            _btnIncome.AddCssClass("success");
             _btnIncome.AddCssClass("denaro-income");
-            _btnExpense.RemoveCssClass("error");
             _btnExpense.RemoveCssClass("denaro-expense");
         }
         else
         {
-
-            _btnIncome.RemoveCssClass("success");
             _btnIncome.RemoveCssClass("denaro-income");
-            _btnExpense.AddCssClass("error");
             _btnExpense.AddCssClass("denaro-expense");
         }
         if (!_constructing)


### PR DESCRIPTION
Amount labels are not inside buttons, like it was before the latest release. They don't use `accent`, `success` and `error` CSS classes anymore, only existing custom classes (`denaro-income` etc; overriding works like before). These classes now set font weight to bold and use named colors from Adwaita palette, depending on current style (`red_1` for dark style and `red_5` for light style, same for other colors).

| Light | Dark |
| --- | --- |
| ![](https://i.imgur.com/PRGrqaH.png) | ![](https://i.imgur.com/TUiRdQj.png) |

This PR should finally resolve the contrast issue raised in Circle review.