### PR TITLE
GNOME - Same width for pill buttons on main screen

### DIFF
--- a/NickvisionMoney.GNOME/Views/MainWindow.cs
+++ b/NickvisionMoney.GNOME/Views/MainWindow.cs
@@ -394,6 +394,13 @@ public partial class MainWindow
     /// <param name="e">EventArgs</param>
     private async void OnShow(Gtk.Widget sender, EventArgs e)
     {
+        GLib.Functions.TimeoutAddFull(0, 100, (data) =>
+        {
+            var maxBtnWidth = Math.Max(_btnNewAccount.GetAllocatedWidth(), _btnOpenAccount.GetAllocatedWidth());
+            _btnNewAccount.SetSizeRequest(maxBtnWidth, -1);
+            _btnOpenAccount.SetSizeRequest(maxBtnWidth, -1);
+            return false;
+        });
         if (_controller.FileToLaunch != null)
         {
             GLib.Functions.TimeoutAddFull(0, 250, (data) =>


### PR DESCRIPTION
After last changes, a new problem appears. "New Account" and "Open Account" buttons on main screen are not expanded anymore, and as result their width can be different. It's not the case for English, but can be noticeable with other languages, depending on the length of text.

![](https://user-images.githubusercontent.com/117388856/220911634-6b624b2e-b14a-47eb-b15a-479f4cda77fa.png)

The fix is a bit hacky. There's no way to check when a widget's size get changed. And allocated size of a widget when it's realized is not the same when it's actually rendered. That's why I added 100ms delay, and then buttons get equal width.

![](https://user-images.githubusercontent.com/117388856/220912039-278c5300-b588-43e5-b4c4-15d7bcd41b5f.png)
