### PR TITLE
Autoresize sidebar when the content requires more horizontal space

### DIFF
--- a/NickvisionMoney.GNOME/Blueprints/account_view.blp
+++ b/NickvisionMoney.GNOME/Blueprints/account_view.blp
@@ -23,6 +23,7 @@ Adw.Bin _root {
   Adw.Flap _flap {
     flap: Gtk.ScrolledWindow _paneScroll {
       width-request: 360;
+      hscrollbar-policy: never;
     
       Gtk.Box {
         orientation: vertical;


### PR DESCRIPTION
I was wrong about not being able to make sidebar autoresize using properties: `hscrollbar-policy` set to `never` doesn't allow `Gtk.ScrolledWindow` to create horizontal scrollbar - it gets resized instead, exactly what we need.

Closes #344 

Screenshot with `ur_PK` locale:

![](https://user-images.githubusercontent.com/117388856/224147834-8a0ba2ff-a622-47b5-91b8-d2563e3e43b9.png)
