### PR TITLE
GNOME - Fix files opening (use Gtk.FileDialog; open files on start)

### DIFF
--- a/NickvisionMoney.GNOME/Controls/GroupRow.cs
+++ b/NickvisionMoney.GNOME/Controls/GroupRow.cs
@@ -14,7 +14,7 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
 {
     private CultureInfo _cultureAmount;
     private CultureInfo _cultureDate;
-    
+
     [Gtk.Connect] private readonly Gtk.CheckButton _filterCheckButton;
     [Gtk.Connect] private readonly Gtk.Label _amountLabel;
     [Gtk.Connect] private readonly Gtk.Button _editButton;

--- a/NickvisionMoney.GNOME/Controls/TransactionRow.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionRow.cs
@@ -63,7 +63,7 @@ public partial class TransactionRow : Adw.PreferencesGroup, IModelRowControl<Tra
     /// </summary>
     public event EventHandler<uint>? DeleteTriggered;
 
-        private TransactionRow(Gtk.Builder builder, Transaction transaction, CultureInfo cultureAmount, CultureInfo cultureDate, Localizer localizer) : base(builder.GetPointer("_root"), false)
+    private TransactionRow(Gtk.Builder builder, Transaction transaction, CultureInfo cultureAmount, CultureInfo cultureDate, Localizer localizer) : base(builder.GetPointer("_root"), false)
     {
         _cultureAmount = cultureAmount;
         _cultureDate = cultureDate;

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -21,9 +21,6 @@ public partial class Program
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial void g_resources_register(nint file);
 
-    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial string g_file_get_path(nint file);
-
     private readonly Adw.Application _application;
     private MainWindow? _mainWindow;
     private MainWindowController _mainWindowController;
@@ -122,7 +119,7 @@ public partial class Program
     {
         if (e.NFiles > 0)
         {
-            var pathOfFirstFile = g_file_get_path(e.Files[0].Handle);
+            var pathOfFirstFile = e.Files[0].GetPath();
             _mainWindowController.FileToLaunch = pathOfFirstFile;
             OnActivate(_application, EventArgs.Empty);
         }

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -69,11 +69,11 @@ public partial class Program
             };
             foreach (var prefix in prefixes)
             {
-               if (File.Exists(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource"))
-               {
-                   g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
-                   break;
-               }
+                if (File.Exists(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource"))
+                {
+                    g_resources_register(g_resource_load(Path.GetFullPath(prefix + "/share/org.nickvision.money/org.nickvision.money.gresource")));
+                    break;
+                }
             }
         }
     }

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -21,6 +21,14 @@ public partial class Program
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial void g_resources_register(nint file);
 
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial string g_file_get_path(nint file);
+
+    private delegate void OpenCallback(nint application, nint[] files, int n_files, nint hint, nint data);
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial ulong g_signal_connect_data(nint instance, string signal, OpenCallback callback, nint data, nint destroy_data, int flags);
+
     private readonly Adw.Application _application;
     private MainWindow? _mainWindow;
     private MainWindowController _mainWindowController;
@@ -54,7 +62,7 @@ public partial class Program
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionMoney/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionMoney/discussions");
         _application.OnActivate += OnActivate;
-        _application.OnOpen += OnOpen;
+        g_signal_connect_data(_application.Handle, "open", OnOpen, IntPtr.Zero, IntPtr.Zero, 0);
         if (File.Exists(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.money.gresource"))
         {
             //Load file from program directory, required for `dotnet run`
@@ -115,12 +123,11 @@ public partial class Program
     /// </summary>
     /// <param name="sender">Gio.Application</param>
     /// <param name="e">Gio.Application.OpenSignalArgs</param>
-    private void OnOpen(Gio.Application sender, Gio.Application.OpenSignalArgs e)
+    private void OnOpen(nint application, nint[] files, int n_files, nint hint, nint data)
     {
-        if (e.NFiles > 0)
+        if (n_files > 0)
         {
-            var pathOfFirstFile = e.Files[0].GetPath();
-            _mainWindowController.FileToLaunch = pathOfFirstFile;
+            _mainWindowController.FileToLaunch = g_file_get_path(files[0]);
             OnActivate(_application, EventArgs.Empty);
         }
     }

--- a/NickvisionMoney.GNOME/Views/MainWindow.cs
+++ b/NickvisionMoney.GNOME/Views/MainWindow.cs
@@ -34,6 +34,32 @@ public partial class MainWindow : Adw.ApplicationWindow
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial void gtk_css_provider_load_from_data(nint provider, string data, int length);
 
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial uint gtk_get_minor_version();
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint gtk_file_dialog_new();
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial void gtk_file_dialog_set_title(nint dialog, string title);
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial void gtk_file_dialog_set_filters(nint dialog, nint filters);
+
+    private delegate void GAsyncReadyCallback(nint source, nint res, nint user_data);
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial void gtk_file_dialog_open(nint dialog, nint parent, nint cancellable, GAsyncReadyCallback callback, nint user_data);
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint gtk_file_dialog_open_finish(nint dialog, nint result, nint error);
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial void gtk_file_dialog_save(nint dialog, nint parent, nint cancellable, GAsyncReadyCallback callback, nint user_data);
+
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint gtk_file_dialog_save_finish(nint dialog, nint result, nint error);
+
     private readonly MainWindowController _controller;
     private readonly Adw.Application _application;
 
@@ -278,32 +304,65 @@ public partial class MainWindow : Adw.ApplicationWindow
     private void OnNewAccount(Gio.SimpleAction sender, EventArgs e)
     {
         _accountPopover.Popdown();
-        var saveFileDialog = Gtk.FileChooserNative.New(_controller.Localizer["NewAccount"], this, Gtk.FileChooserAction.Save, _controller.Localizer["Save"], _controller.Localizer["Cancel"]);
-        saveFileDialog.SetModal(true);
         var filter = Gtk.FileFilter.New();
         filter.SetName($"{_controller.Localizer["NickvisionMoneyAccount"]} (*.nmoney)");
         filter.AddPattern("*.nmoney");
-        saveFileDialog.AddFilter(filter);
-        saveFileDialog.OnResponse += async (sender, e) =>
+        if (gtk_get_minor_version() >= 9)
         {
-            if (e.ResponseId == (int)Gtk.ResponseType.Accept)
+            var saveFileDialog = gtk_file_dialog_new();
+            gtk_file_dialog_set_title(saveFileDialog, _controller.Localizer["NewAccount"]);
+            var filters = Gio.ListStore.New(Gtk.FileFilter.GetGType());
+            filters.Append(filter);
+            gtk_file_dialog_set_filters(saveFileDialog, filters.Handle);
+            var fileHandle = IntPtr.Zero;
+            GAsyncReadyCallback callback = async (source, res, data) =>
             {
-                var path = saveFileDialog.GetFile()!.GetPath() ?? "";
-                if (_controller.IsAccountOpen(path))
+                fileHandle = gtk_file_dialog_save_finish(saveFileDialog, res, IntPtr.Zero);
+                if (fileHandle != IntPtr.Zero)
                 {
-                    _toastOverlay.AddToast(Adw.Toast.New(_controller.Localizer["UnableToOverride"]));
-                }
-                else
-                {
-                    if (File.Exists(path))
+                    var path = g_file_get_path(fileHandle);
+                    if (_controller.IsAccountOpen(path))
                     {
-                        File.Delete(path);
+                        _toastOverlay.AddToast(Adw.Toast.New(_controller.Localizer["UnableToOverride"]));
                     }
-                    await _controller.AddAccountAsync(path);
+                    else
+                    {
+                        if (File.Exists(path))
+                        {
+                            File.Delete(path);
+                        }
+                        await _controller.AddAccountAsync(path);
+                    }
                 }
-            }
-        };
-        saveFileDialog.Show();
+            };
+            gtk_file_dialog_save(saveFileDialog, this.Handle, IntPtr.Zero, callback, IntPtr.Zero);
+        }
+        else
+        {
+            var saveFileDialog = Gtk.FileChooserNative.New(_controller.Localizer["NewAccount"], this, Gtk.FileChooserAction.Save, _controller.Localizer["Save"], _controller.Localizer["Cancel"]);
+            saveFileDialog.SetModal(true);
+            saveFileDialog.AddFilter(filter);
+            saveFileDialog.OnResponse += async (sender, e) =>
+            {
+                if (e.ResponseId == (int)Gtk.ResponseType.Accept)
+                {
+                    var path = saveFileDialog.GetFile()!.GetPath() ?? "";
+                    if (_controller.IsAccountOpen(path))
+                    {
+                        _toastOverlay.AddToast(Adw.Toast.New(_controller.Localizer["UnableToOverride"]));
+                    }
+                    else
+                    {
+                        if (File.Exists(path))
+                        {
+                            File.Delete(path);
+                        }
+                        await _controller.AddAccountAsync(path);
+                    }
+                }
+            };
+            saveFileDialog.Show();
+        }
     }
 
     /// <summary>
@@ -314,22 +373,44 @@ public partial class MainWindow : Adw.ApplicationWindow
     private void OnOpenAccount(Gio.SimpleAction sender, EventArgs e)
     {
         _accountPopover.Popdown();
-        var openFileDialog = Gtk.FileChooserNative.New(_controller.Localizer["OpenAccount"], this, Gtk.FileChooserAction.Open, _controller.Localizer["Open"], _controller.Localizer["Cancel"]);
-        openFileDialog.SetModal(true);
         var filter = Gtk.FileFilter.New();
         filter.SetName($"{_controller.Localizer["NickvisionMoneyAccount"]} (*.nmoney)");
         filter.AddPattern("*.nmoney");
         filter.AddPattern("*.NMONEY");
-        openFileDialog.AddFilter(filter);
-        openFileDialog.OnResponse += async (sender, e) =>
+        if (gtk_get_minor_version() >= 9)
         {
-            if (e.ResponseId == (int)Gtk.ResponseType.Accept)
+            var openFileDialog = gtk_file_dialog_new();
+            gtk_file_dialog_set_title(openFileDialog, _controller.Localizer["OpenAccount"]);
+            var filters = Gio.ListStore.New(Gtk.FileFilter.GetGType());
+            filters.Append(filter);
+            gtk_file_dialog_set_filters(openFileDialog, filters.Handle);
+            var fileHandle = IntPtr.Zero;
+            GAsyncReadyCallback callback = async (source, res, data) =>
             {
-                var path = openFileDialog.GetFile()!.GetPath() ?? "";
-                await _controller.AddAccountAsync(path);
-            }
-        };
-        openFileDialog.Show();
+                fileHandle = gtk_file_dialog_open_finish(openFileDialog, res, IntPtr.Zero);
+                if (fileHandle != IntPtr.Zero)
+                {
+                    var path = g_file_get_path(fileHandle);
+                    await _controller.AddAccountAsync(path);
+                }
+            };
+            gtk_file_dialog_open(openFileDialog, this.Handle, IntPtr.Zero, callback, IntPtr.Zero);
+        }
+        else
+        {
+            var openFileDialog = Gtk.FileChooserNative.New(_controller.Localizer["OpenAccount"], this, Gtk.FileChooserAction.Open, _controller.Localizer["Open"], _controller.Localizer["Cancel"]);
+            openFileDialog.SetModal(true);
+            openFileDialog.AddFilter(filter);
+            openFileDialog.OnResponse += async (sender, e) =>
+            {
+                if (e.ResponseId == (int)Gtk.ResponseType.Accept)
+                {
+                    var path = openFileDialog.GetFile()!.GetPath() ?? "";
+                    await _controller.AddAccountAsync(path);
+                }
+            };
+            openFileDialog.Show();
+        }
     }
 
     /// <summary>

--- a/NickvisionMoney.GNOME/Views/MainWindow.cs
+++ b/NickvisionMoney.GNOME/Views/MainWindow.cs
@@ -35,9 +35,6 @@ public partial class MainWindow : Adw.ApplicationWindow
     private static partial void gtk_css_provider_load_from_data(nint provider, string data, int length);
 
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial uint gtk_get_minor_version();
-
-    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial nint gtk_file_dialog_new();
 
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
@@ -307,7 +304,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         var filter = Gtk.FileFilter.New();
         filter.SetName($"{_controller.Localizer["NickvisionMoneyAccount"]} (*.nmoney)");
         filter.AddPattern("*.nmoney");
-        if (gtk_get_minor_version() >= 9)
+        if (Gtk.Functions.GetMinorVersion() >= 9)
         {
             var saveFileDialog = gtk_file_dialog_new();
             gtk_file_dialog_set_title(saveFileDialog, _controller.Localizer["NewAccount"]);
@@ -335,7 +332,7 @@ public partial class MainWindow : Adw.ApplicationWindow
                     }
                 }
             };
-            gtk_file_dialog_save(saveFileDialog, this.Handle, IntPtr.Zero, callback, IntPtr.Zero);
+            gtk_file_dialog_save(saveFileDialog, Handle, IntPtr.Zero, callback, IntPtr.Zero);
         }
         else
         {
@@ -377,7 +374,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         filter.SetName($"{_controller.Localizer["NickvisionMoneyAccount"]} (*.nmoney)");
         filter.AddPattern("*.nmoney");
         filter.AddPattern("*.NMONEY");
-        if (gtk_get_minor_version() >= 9)
+        if (Gtk.Functions.GetMinorVersion() >= 9)
         {
             var openFileDialog = gtk_file_dialog_new();
             gtk_file_dialog_set_title(openFileDialog, _controller.Localizer["OpenAccount"]);

--- a/NickvisionMoney.GNOME/justfile
+++ b/NickvisionMoney.GNOME/justfile
@@ -51,7 +51,7 @@ publish PREFIX LIB_DIR=lib: clean && (_occitan_fix PREFIX LIB_DIR) (_install_ext
     mkdir -p {{builddir}}{{PREFIX}}/bin
     cat > {{builddir}}{{PREFIX}}/bin/{{app_id}} << EOF
     #!/bin/sh
-    exec dotnet {{PREFIX}}/{{LIB_DIR}}/{{app_id}}/{{project_name}}.GNOME.dll
+    exec dotnet {{PREFIX}}/{{LIB_DIR}}/{{app_id}}/{{project_name}}.GNOME.dll \$@
     EOF
     chmod +x {{builddir}}{{PREFIX}}/bin/{{app_id}}
 
@@ -82,7 +82,7 @@ publish-self-contained PREFIX LIB_DIR=lib: clean && (_occitan_fix PREFIX LIB_DIR
     mkdir -p {{builddir}}{{PREFIX}}/bin
     cat > {{builddir}}{{PREFIX}}/bin/{{app_id}} << EOF
     #!/bin/sh
-    exec {{PREFIX}}/{{LIB_DIR}}/{{app_id}}/{{project_name}}.GNOME
+    exec {{PREFIX}}/{{LIB_DIR}}/{{app_id}}/{{project_name}}.GNOME \$@
     EOF
     chmod +x {{builddir}}{{PREFIX}}/bin/{{app_id}}
 

--- a/NickvisionMoney.Shared/Models/Configuration.cs
+++ b/NickvisionMoney.Shared/Models/Configuration.cs
@@ -21,7 +21,7 @@ public enum InsertSeparator
 /// </summary>
 public class Configuration
 {
-    private static readonly string ConfigDir = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}Nickvision{Path.DirectorySeparatorChar}{AppInfo.Current.Name}";
+    public static readonly string ConfigDir = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}Nickvision{Path.DirectorySeparatorChar}{AppInfo.Current.Name}";
     private static readonly string ConfigPath = $"{ConfigDir}{Path.DirectorySeparatorChar}config.json";
     private static Configuration? _instance;
 


### PR DESCRIPTION
Hello a ton of marshalling, long time no see 😄 

### The problem

When running with GTK 4.9+, `Gtk.FileChooserNative` becomes unusable (missing labels and icons - [screenshot](https://user-images.githubusercontent.com/117388856/224332396-2031cf63-67ad-423b-8e55-ac8b75831370.png) - trying to blindly open a file crashes the app).
I'm not entirely sure what causes the problem, but I guess it's somehow related to gir.core because I didn't find any other app other than Denaro and TC that has this bug. But I think gir.core devs have more important stuff than fixing deprecated things, so I didn't report it.

### Temporary solution

`Gtk.FileChooserNative` and `Gtk.FileChooserDialog` are deprecated in favor of `Gtk.FileDialog` added in GTK 4.9.1. In this PR Denaro uses this new widget when running with supported GTK version.
I tested this PR in Fedora 37 (GTK 4.8.3), Fedora 38 Beta (GTK 4.9) and in Arch distrobox (GTK 4.10).

### Long-term solution

When GNOME 44 Platform runtime will be released with GTK 4.10 I suggest to use it and completely remove `Gtk.FileChooserNative`. This will make 4.10 minimum required version of GTK, but I think people who use distros with old libraries should use Flatpak anyway, so this will not be a problem. And when gir.core will support GTK 4.10 we'll get rid of marshalling.
Because the code will be changed, I don't think we should copy everything to Application now. But after accepting this PR I will open a new PR for TC.

### A new small issue

`Gtk.FileDialog` when used to open a file has a checkbox to open a file in read-only mode that can't be hidden. This doesn't break Denaro, because we only use resulting `Gio.File` to get the path and then Denaro opens the file read-write anyway. But this can be misleading for users, so maybe we should consider adding read-only mode to Denaro in the future.

**UPD**: Also fixed files opening on start.