### PR TITLE
Fix QIF loading with non-English locale

### DIFF
--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -1323,10 +1323,10 @@ public class Account : IDisposable
         QifDocument? qif = null;
         try
         {
-            qif = Task.Run(() => {
-                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
-                return QifDocument.Load(File.OpenRead(path));
-            }).Result;
+            var oldCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            qif = QifDocument.Load(File.OpenRead(path));
+            Thread.CurrentThread.CurrentCulture = oldCulture;
         }
         catch
         {

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -14,6 +14,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NickvisionMoney.Shared.Models;
@@ -1322,7 +1323,10 @@ public class Account : IDisposable
         QifDocument? qif = null;
         try
         {
-            qif = QifDocument.Load(File.OpenRead(path));
+            qif = Task.Run(() => {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+                return QifDocument.Load(File.OpenRead(path));
+            }).Result;
         }
         catch
         {


### PR DESCRIPTION
`QifDocument.Load` fails if the current culture is not en-US. Function call is now wrapped in `Task.Run` to be executed in separated thread where culture is changed without affecting the rest of the app.
Closes #368 