### PR TITLE
Show Number Of Filtered Transactions

### DIFF
--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -422,7 +422,6 @@ public partial class AccountView : Adw.Bin
         {
             ((TransactionRow)_flowBox.GetChildAtIndex(i)!.GetChild()!).Container = _flowBox.GetChildAtIndex(i);
         }
-        _transactionsGroup.SetTitle($"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}");
         //Setup Other UI Elements
         _sortTransactionByDropDown.SetSelected((uint)_controller.SortTransactionsBy);
         if (_controller.SortFirstToLast)
@@ -1293,7 +1292,7 @@ public partial class AccountView : Adw.Bin
         }
         else
         {
-            _transactionsGroup.SetTitle(_controller.Localizer["Transactions"]);
+            _transactionsGroup.SetTitle($"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}");
         }
     }
 }

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -461,7 +461,7 @@ public partial class AccountView : Adw.Bin
             if (_controller.TransactionsCount > 0)
             {
                 OnCalendarMonthYearChanged(null, EventArgs.Empty);
-                _transactionsGroup.SetTitle($"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}");
+                _transactionsGroup.SetTitle(string.Format(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["TransactionNumber", "Plural"] : _controller.Localizer["TransactionNumber"], _controller.FilteredTransactionsCount));
                 if (_controller.FilteredTransactionsCount > 0)
                 {
                     _noTransactionsStatusPage.SetVisible(false);
@@ -1292,7 +1292,7 @@ public partial class AccountView : Adw.Bin
         }
         else
         {
-            _transactionsGroup.SetTitle($"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}");
+            _transactionsGroup.SetTitle(string.Format(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["TransactionNumber", "Plural"] : _controller.Localizer["TransactionNumber"], _controller.FilteredTransactionsCount));
         }
     }
 }

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -422,6 +422,7 @@ public partial class AccountView : Adw.Bin
         {
             ((TransactionRow)_flowBox.GetChildAtIndex(i)!.GetChild()!).Container = _flowBox.GetChildAtIndex(i);
         }
+        _transactionsGroup.SetTitle($"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}");
         //Setup Other UI Elements
         _sortTransactionByDropDown.SetSelected((uint)_controller.SortTransactionsBy);
         if (_controller.SortFirstToLast)
@@ -461,7 +462,8 @@ public partial class AccountView : Adw.Bin
             if (_controller.TransactionsCount > 0)
             {
                 OnCalendarMonthYearChanged(null, EventArgs.Empty);
-                if (_controller.HasFilteredTransactions)
+                _transactionsGroup.SetTitle($"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}");
+                if (_controller.FilteredTransactionsCount > 0)
                 {
                     _noTransactionsStatusPage.SetVisible(false);
                     _transactionsScroll.SetVisible(true);

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -28,9 +28,9 @@ public class AccountViewController : IDisposable
     /// </summary>
     public Localizer Localizer { get; init; }
     /// <summary>
-    /// Whether or not filtered transactions are available
+    /// The number of filtered transactions being shown
     /// </summary>
-    public bool HasFilteredTransactions { get; private set; }
+    public int FilteredTransactionsCount { get; private set; }
     /// <summary>
     /// The list of UI transaction row objects
     /// </summary>
@@ -149,7 +149,7 @@ public class AccountViewController : IDisposable
         GroupRows = new Dictionary<uint, IGroupRowControl>();
         _filters = new Dictionary<int, bool>();
         Localizer = localizer;
-        HasFilteredTransactions = false;
+        FilteredTransactionsCount = 0;
         NotificationSent = notificationSent;
         RecentAccountsChanged = recentAccountsChanged;
         //Setup Filters
@@ -455,7 +455,7 @@ public class AccountViewController : IDisposable
             {
                 TransactionRows.Add(transaction.Id, UICreateTransactionRow!(transaction, null));
             }
-            HasFilteredTransactions = transactions.Count > 0;
+            FilteredTransactionsCount = transactions.Count;
             AccountTransactionsChanged?.Invoke(this, EventArgs.Empty);
             _isOpened = true;
         }
@@ -1036,8 +1036,8 @@ public class AccountViewController : IDisposable
             }
             filteredTransactions.Add(pair.Value.Id);
         }
-        HasFilteredTransactions = filteredTransactions.Count > 0;
-        if (HasFilteredTransactions)
+        FilteredTransactionsCount = filteredTransactions.Count;
+        if (FilteredTransactionsCount > 0)
         {
             //Update UI
             foreach (var pair in TransactionRows)

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -300,6 +300,10 @@
 		<value>Groups</value>
 	</data>
 
+	<data name="Transaction" xml:space="preserve">
+		<value>Transaction</value>
+	</data>
+
 	<data name="Transactions" xml:space="preserve">
 		<value>Transactions</value>
 	</data>

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -300,12 +300,16 @@
 		<value>Groups</value>
 	</data>
 
-	<data name="Transaction" xml:space="preserve">
-		<value>Transaction</value>
-	</data>
-
 	<data name="Transactions" xml:space="preserve">
 		<value>Transactions</value>
+	</data>
+
+	<data name="TransactionNumber" xml:space="preserve">
+		<value>{0} Transaction</value>
+	</data>
+
+	<data name="TransactionNumber.Plural" xml:space="preserve">
+		<value>{0} Transactions</value>
 	</data>
 
 	<data name="NoTransactionsTitle" xml:space="preserve">

--- a/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
@@ -232,6 +232,7 @@ public sealed partial class AccountView : UserControl, INotifyPropertyChanged
             }
             ScrollSidebar.Height = ActualHeight - 60;
             GridSidebar.Margin = new Thickness(0, 0, ScrollSidebar.Height < GridSidebar.ActualHeight ? 14 : 0, 0);
+            LblTransactions.Text = $"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}";
             //Setup Other UI Elements
             DateRangeStart.Date = DateTimeOffset.Now;
             DateRangeEnd.Date = DateTimeOffset.Now;
@@ -327,7 +328,8 @@ public sealed partial class AccountView : UserControl, INotifyPropertyChanged
                 }
             }
             //Transaction Page
-            if (_controller.HasFilteredTransactions)
+            LblTransactions.Text = $"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}";
+            if (_controller.FilteredTransactionsCount > 0)
             {
                 ViewStackTransactions.ChangePage("Transactions");
             }

--- a/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
@@ -232,7 +232,7 @@ public sealed partial class AccountView : UserControl, INotifyPropertyChanged
             }
             ScrollSidebar.Height = ActualHeight - 60;
             GridSidebar.Margin = new Thickness(0, 0, ScrollSidebar.Height < GridSidebar.ActualHeight ? 14 : 0, 0);
-            LblTransactions.Text = $"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}";
+            LblTransactions.Text = string.Format(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["TransactionNumber", "Plural"] : _controller.Localizer["TransactionNumber"], _controller.FilteredTransactionsCount);
             //Setup Other UI Elements
             DateRangeStart.Date = DateTimeOffset.Now;
             DateRangeEnd.Date = DateTimeOffset.Now;
@@ -328,7 +328,7 @@ public sealed partial class AccountView : UserControl, INotifyPropertyChanged
                 }
             }
             //Transaction Page
-            LblTransactions.Text = $"{_controller.FilteredTransactionsCount} {(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["Transactions"] : _controller.Localizer["Transaction"])}";
+            LblTransactions.Text = string.Format(_controller.FilteredTransactionsCount != 1 ? _controller.Localizer["TransactionNumber", "Plural"] : _controller.Localizer["TransactionNumber"], _controller.FilteredTransactionsCount);
             if (_controller.FilteredTransactionsCount > 0)
             {
                 ViewStackTransactions.ChangePage("Transactions");


### PR DESCRIPTION
This PR modifies the `Transactions` group title to show the number of transactions being shown based of the current filters.

## GNOME
![image](https://user-images.githubusercontent.com/17648453/225496117-55fe55d8-3a7e-4c62-8805-9378fac2c153.png)
![image](https://user-images.githubusercontent.com/17648453/225496149-9eeebb8d-6ce5-44e1-9b0c-9c134916cb12.png)
![image](https://user-images.githubusercontent.com/17648453/225496179-e45c6171-166c-4e4a-833e-71ff2a4ad39a.png)

## WinUI
![image](https://user-images.githubusercontent.com/17648453/225496252-cd3bc796-a722-4a34-81f4-6b85309cc27f.png)
