### PR TITLE
Fix calculation of NextAvailableTransactionID

### DIFF
--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -500,12 +500,11 @@ public class Account : IDisposable
                     TodayExpense += transaction.Amount;
                 }
             }
-            if (transaction.Id > NextAvailableTransactionId)
+            if (transaction.Id >= NextAvailableTransactionId)
             {
-                NextAvailableTransactionId = transaction.Id;
+                NextAvailableTransactionId = transaction.Id + 1;
             }
         }
-        NextAvailableTransactionId++;
         //Repeats
         await SyncRepeatTransactionsAsync();
         //Cleanup
@@ -835,7 +834,10 @@ public class Account : IDisposable
         if (await cmdAddTransaction.ExecuteNonQueryAsync() > 0)
         {
             Transactions.Add(transaction.Id, transaction);
-            NextAvailableTransactionId++;
+            if (transaction.Id >= NextAvailableTransactionId)
+            {
+                NextAvailableTransactionId = transaction.Id + 1;
+            }
             if (transaction.Date <= DateOnly.FromDateTime(DateTime.Now))
             {
                 var groupId = transaction.GroupId == -1 ? 0u : (uint)transaction.GroupId;


### PR DESCRIPTION
Closes #405 
The part in `LoadAsync` didn't really need to be changed, but I thought it would be better if it matched the same operation in `AddTransactionAsync`.