### PR TITLE
Declare adaptiveness in desktop file

### DIFF
--- a/NickvisionMoney.GNOME/org.nickvision.money.desktop
+++ b/NickvisionMoney.GNOME/org.nickvision.money.desktop
@@ -11,3 +11,5 @@ X-GNOME-UsesNotifications=true
 Categories=Office;Finance;
 Keywords=money;finance;wallet;cash;bank;GTK;Nickvision;
 StartupNotify = true
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
As specified in https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/ both metainfo and .desktop file need to have declared adaptiveness to mobile sizes. While Denaro's metainfo already has that, the .desktop file was missing that.

This declaration in .desktop file would allow Phosh to list Denaro when showing which apps are adaptive to mobile size, in the app drawer.