### PR TITLE
Group Color Fixes

### DIFF
--- a/NickvisionMoney.GNOME/Controls/GroupRow.cs
+++ b/NickvisionMoney.GNOME/Controls/GroupRow.cs
@@ -127,7 +127,7 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
         _amountLabel.SetVexpand(group.Id == 0);
         _editButton.OnClicked += Edit;
         _deleteButton.OnClicked += Delete;
-        UpdateRow(group, cultureAmount, filterActive);
+        UpdateRow(group, defaultColor, cultureAmount, filterActive);
     }
 
     /// <summary>
@@ -156,11 +156,13 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
     /// Updates the row with the new model
     /// </summary>
     /// <param name="group">The new Group model</param>
+    /// <param name="defaultColor">The default color for the row</param>
     /// <param name="cultureAmount">The culture to use for displaying amount strings</param>
     /// <param name="filterActive">Whether or not the filter checkbox is active</param>
-    public void UpdateRow(Group group, CultureInfo cultureAmount, bool filterActive)
+    public void UpdateRow(Group group, string defaultColor, CultureInfo cultureAmount, bool filterActive)
     {
         _group = group;
+        _defaultColor = defaultColor;
         _filterActive = filterActive;
         _cultureAmount = cultureAmount;
         g_main_context_invoke(IntPtr.Zero, _updateCallback, IntPtr.Zero);

--- a/NickvisionMoney.GNOME/Controls/TransactionId.cs
+++ b/NickvisionMoney.GNOME/Controls/TransactionId.cs
@@ -25,15 +25,13 @@ public partial class TransactionId : Gtk.Overlay
     private readonly Gtk.SizeGroup _sizeGroup;
     private readonly GdkPixbuf.Pixbuf _pixbuf;
     private readonly uint _id;
-    private readonly string _defaultColor;
 
     [Gtk.Connect] private readonly Gtk.Image _colorImage;
     [Gtk.Connect] private readonly Gtk.Label _idLabel;
 
-    private TransactionId(Gtk.Builder builder, uint id, string defaultColor) : base(builder.GetPointer("_root"), false)
+    private TransactionId(Gtk.Builder builder, uint id) : base(builder.GetPointer("_root"), false)
     {
         _id = id;
-        _defaultColor = defaultColor;
         builder.Connect(this);
         _pixbuf = GdkPixbuf.Pixbuf.New(GdkPixbuf.Colorspace.Rgb, false, 8, 1, 1);
         _sizeGroup = Gtk.SizeGroup.New(Gtk.SizeGroupMode.Horizontal);
@@ -45,9 +43,8 @@ public partial class TransactionId : Gtk.Overlay
     /// Constructs a TransactionId widget
     /// </summary>
     /// <param name="id">Transaction Id</param>
-    /// <param name="defaultColor">Default transaction color</param>
     /// <param name="localizer">The Localizer for the app</param>
-    public TransactionId(uint id, string defaultColor, Localizer localizer) : this(Builder.FromFile("transaction_id.ui", localizer), id, defaultColor)
+    public TransactionId(uint id, Localizer localizer) : this(Builder.FromFile("transaction_id.ui", localizer), id)
     {
     }
 
@@ -55,12 +52,13 @@ public partial class TransactionId : Gtk.Overlay
     /// Updates the color of widget
     /// </summary>
     /// <param name="colorString">Transaction color</param>
-    public void UpdateColor(string colorString)
+    /// <param name="defaultColor">A default color</param>
+    public void UpdateColor(string colorString, string defaultColor)
     {
         var color = new Color();
         if (!gdk_rgba_parse(ref color, colorString))
         {
-            gdk_rgba_parse(ref color, _defaultColor);
+            gdk_rgba_parse(ref color, defaultColor);
         }
         var red = (int)(color.Red * 255);
         var green = (int)(color.Green * 255);

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -1086,7 +1086,7 @@ public partial class AccountView : Adw.Bin
             {
                 try
                 {
-                    await _controller.UpdateGroupAsync(groupController.Group);
+                    await _controller.UpdateGroupAsync(groupController.Group, groupController.HasColorChanged);
                 }
                 catch (Exception ex)
                 {

--- a/NickvisionMoney.GNOME/Views/DashboardView.cs
+++ b/NickvisionMoney.GNOME/Views/DashboardView.cs
@@ -2,7 +2,6 @@ using NickvisionMoney.GNOME.Controls;
 using NickvisionMoney.GNOME.Helpers;
 using NickvisionMoney.Shared.Controllers;
 using NickvisionMoney.Shared.Helpers;
-using System;
 using System.Globalization;
 
 namespace NickvisionMoney.GNOME.Views;

--- a/NickvisionMoney.GNOME/Views/DashboardView.cs
+++ b/NickvisionMoney.GNOME/Views/DashboardView.cs
@@ -59,8 +59,8 @@ public class DashboardView : Gtk.ScrolledWindow
             var row = Adw.ActionRow.New();
             row.SetTitle(pair.Key);
             row.AddCssClass("card");
-            var prefix = new TransactionId(0, "", controller.Localizer);
-            prefix.UpdateColor(pair.Value.RGBA);
+            var prefix = new TransactionId(0, controller.Localizer);
+            prefix.UpdateColor(pair.Value.RGBA, "");
             prefix.SetCompact(true);
             row.AddPrefix(prefix);
             var suffixBox = Gtk.Box.New(Gtk.Orientation.Vertical, 1);

--- a/NickvisionMoney.GNOME/Views/GroupDialog.cs
+++ b/NickvisionMoney.GNOME/Views/GroupDialog.cs
@@ -39,7 +39,7 @@ public partial class GroupDialog : Adw.Window
     private static partial nint gtk_color_dialog_new();
 
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial void gtk_color_dialog_set_with_alpha(nint dialog, [MarshalAs(UnmanagedType.I1)]bool with_alpha);
+    private static partial void gtk_color_dialog_set_with_alpha(nint dialog, [MarshalAs(UnmanagedType.I1)] bool with_alpha);
 
     private bool _constructing;
     private readonly GroupDialogController _controller;

--- a/NickvisionMoney.GNOME/Views/PreferencesDialog.cs
+++ b/NickvisionMoney.GNOME/Views/PreferencesDialog.cs
@@ -40,7 +40,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
     private static partial nint gtk_color_dialog_new();
 
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial void gtk_color_dialog_set_with_alpha(nint dialog, [MarshalAs(UnmanagedType.I1)]bool with_alpha);
+    private static partial void gtk_color_dialog_set_with_alpha(nint dialog, [MarshalAs(UnmanagedType.I1)] bool with_alpha);
 
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial string g_file_get_path(nint file);

--- a/NickvisionMoney.GNOME/Views/TransactionDialog.cs
+++ b/NickvisionMoney.GNOME/Views/TransactionDialog.cs
@@ -3,8 +3,6 @@ using NickvisionMoney.Shared.Controllers;
 using NickvisionMoney.Shared.Helpers;
 using NickvisionMoney.Shared.Models;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace NickvisionMoney.GNOME.Views;
@@ -53,7 +51,7 @@ public partial class TransactionDialog : Adw.Window
     private static partial nint gtk_color_dialog_new();
 
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial void gtk_color_dialog_set_with_alpha(nint dialog, [MarshalAs(UnmanagedType.I1)]bool with_alpha);
+    private static partial void gtk_color_dialog_set_with_alpha(nint dialog, [MarshalAs(UnmanagedType.I1)] bool with_alpha);
 
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial int g_date_time_get_year(ref MoneyDateTime datetime);

--- a/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
@@ -154,11 +154,11 @@ public class AccountSettingsDialogController
         {
             result |= AccountMetadataCheckStatus.SameSeparators;
         }
-        if (useCustom && !string.IsNullOrEmpty(customDecimalSeparator) && customSymbol.Contains(customDecimalSeparator))
+        if (useCustom && !string.IsNullOrEmpty(customDecimalSeparator) && customSymbol!.Contains(customDecimalSeparator))
         {
             result |= AccountMetadataCheckStatus.SameSymbolAndDecimalSeparator;
         }
-        if (useCustom && !string.IsNullOrEmpty(customGroupSeparator) && customSymbol.Contains(customGroupSeparator))
+        if (useCustom && !string.IsNullOrEmpty(customGroupSeparator) && customSymbol!.Contains(customGroupSeparator))
         {
             result |= AccountMetadataCheckStatus.SameSymbolAndGroupSeparator;
         }

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -843,10 +843,14 @@ public class AccountViewController : IDisposable
     /// <param name="id">The id of the group to delete</param>
     public async Task DeleteGroupAsync(uint id)
     {
-        await _account.DeleteGroupAsync(id);
+        var result = await _account.DeleteGroupAsync(id, TransactionDefaultColor);
         _filters.Remove((int)id);
         UIDeleteGroupRow!(GroupRows[id]);
         GroupRows.Remove(id);
+        foreach(var transaction in result.BelongingTransactions)
+        {
+            TransactionRows[transaction].UpdateRow(_account.Transactions[transaction], TransactionDefaultColor, CultureForNumberString, CultureForDateString);
+        }
     }
 
     /// <summary>

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -825,9 +825,9 @@ public class AccountViewController : IDisposable
     {
         await _account.UpdateGroupAsync(group);
         GroupRows[group.Id].UpdateRow(group, GroupDefaultColor, CultureForNumberString, _filters[(int)group.Id]);
-        if(hasColorChanged)
+        if (hasColorChanged)
         {
-            foreach(var pair in _account.Transactions)
+            foreach (var pair in _account.Transactions)
             {
                 if (pair.Value.GroupId == group.Id)
                 {

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -809,10 +809,20 @@ public class AccountViewController : IDisposable
     /// Updates a group in the account
     /// </summary>
     /// <param name="group">The group to update</param>
-    public async Task UpdateGroupAsync(Group group)
+    public async Task UpdateGroupAsync(Group group, bool hasColorChanged)
     {
         await _account.UpdateGroupAsync(group);
         GroupRows[group.Id].UpdateRow(group, CultureForNumberString, _filters[(int)group.Id]);
+        if(hasColorChanged)
+        {
+            foreach(var pair in _account.Transactions)
+            {
+                if (pair.Value.GroupId == group.Id)
+                {
+                    TransactionRows[pair.Key].UpdateRow(pair.Value, CultureForNumberString.Parent, CultureForDateString);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -831,7 +831,7 @@ public class AccountViewController : IDisposable
             {
                 if (pair.Value.GroupId == group.Id)
                 {
-                    TransactionRows[pair.Key].UpdateRow(pair.Value, TransactionDefaultColor, CultureForNumberString.Parent, CultureForDateString);
+                    TransactionRows[pair.Key].UpdateRow(pair.Value, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
                 }
             }
         }

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -469,6 +469,8 @@ public class AccountViewController : IDisposable
             }
             FilteredTransactionsCount = transactions.Count;
             AccountTransactionsChanged?.Invoke(this, EventArgs.Empty);
+            //Register Events
+            Configuration.Current.Saved += ConfigurationChanged;
             _isOpened = true;
         }
     }
@@ -552,6 +554,16 @@ public class AccountViewController : IDisposable
     public TransferDialogController CreateTransferDialogController() => new TransferDialogController(new Transfer(AccountPath, AccountTitle), _account.TodayTotal, Configuration.Current.RecentAccounts, CultureForNumberString, Localizer);
 
     /// <summary>
+    /// Occurs when the configuration is changed
+    /// </summary>
+    /// <param name="sender">object?</param>
+    /// <param name="e">EventArgs</param>
+    private void ConfigurationChanged(object? sender, EventArgs e)
+    {
+        GroupRows[0].UpdateRow(Groups[0], GroupDefaultColor, CultureForNumberString, _filters[-1]);
+    }
+
+    /// <summary>
     /// Sets the new password of the account
     /// </summary>
     /// <param name="password">The new password</param>
@@ -591,11 +603,11 @@ public class AccountViewController : IDisposable
         {
             foreach (var row in GroupRows)
             {
-                row.Value.UpdateRow(_account.Groups[row.Key], CultureForNumberString, _filters[(int)row.Key]);
+                row.Value.UpdateRow(_account.Groups[row.Key], GroupDefaultColor, CultureForNumberString, _filters[(int)row.Key]);
             }
             foreach (var row in TransactionRows)
             {
-                row.Value.UpdateRow(_account.Transactions[row.Key], CultureForNumberString, CultureForDateString);
+                row.Value.UpdateRow(_account.Transactions[row.Key], TransactionDefaultColor, CultureForNumberString, CultureForDateString);
             }
         }
         AccountTransactionsChanged?.Invoke(this, EventArgs.Empty);
@@ -630,7 +642,7 @@ public class AccountViewController : IDisposable
                 TransactionRows.Add(_account.Transactions[transactions[i]].Id, UICreateTransactionRow!(_account.Transactions[transactions[i]], i));
             }
         }
-        GroupRows[groupId].UpdateRow(_account.Groups[groupId], CultureForNumberString, _filters[(int)groupId]);
+        GroupRows[groupId].UpdateRow(_account.Groups[groupId], GroupDefaultColor, CultureForNumberString, _filters[(int)groupId]);
         FilterUIUpdate();
     }
 
@@ -643,7 +655,7 @@ public class AccountViewController : IDisposable
         var originalGroupId = _account.Transactions[transaction.Id].GroupId == -1 ? 0u : (uint)_account.Transactions[transaction.Id].GroupId;
         var newGroupId = transaction.GroupId == -1 ? 0u : (uint)transaction.GroupId;
         await _account.UpdateTransactionAsync(transaction);
-        TransactionRows[transaction.Id].UpdateRow(transaction, CultureForNumberString, CultureForDateString);
+        TransactionRows[transaction.Id].UpdateRow(transaction, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
         if (transaction.RepeatInterval != TransactionRepeatInterval.Never)
         {
             foreach (var pair in _account.Transactions)
@@ -654,8 +666,8 @@ public class AccountViewController : IDisposable
                 }
             }
         }
-        GroupRows[originalGroupId].UpdateRow(_account.Groups[originalGroupId], CultureForNumberString, _filters[(int)originalGroupId]);
-        GroupRows[newGroupId].UpdateRow(_account.Groups[newGroupId], CultureForNumberString, _filters[(int)newGroupId]);
+        GroupRows[originalGroupId].UpdateRow(_account.Groups[originalGroupId], GroupDefaultColor, CultureForNumberString, _filters[(int)originalGroupId]);
+        GroupRows[newGroupId].UpdateRow(_account.Groups[newGroupId], GroupDefaultColor, CultureForNumberString, _filters[(int)newGroupId]);
         FilterUIUpdate();
     }
 
@@ -669,14 +681,14 @@ public class AccountViewController : IDisposable
         var originalGroupId = _account.Transactions[transaction.Id].GroupId == -1 ? 0u : (uint)_account.Transactions[transaction.Id].GroupId;
         var newGroupId = transaction.GroupId == -1 ? 0u : (uint)transaction.GroupId;
         await _account.UpdateSourceTransactionAsync(transaction, updateGenerated);
-        TransactionRows[transaction.Id].UpdateRow(transaction, CultureForNumberString, CultureForDateString);
+        TransactionRows[transaction.Id].UpdateRow(transaction, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
         foreach (var pair in _account.Transactions)
         {
             if (updateGenerated && pair.Value.RepeatFrom == transaction.Id)
             {
                 if (TransactionRows.ContainsKey(pair.Key))
                 {
-                    TransactionRows[pair.Value.Id].UpdateRow(pair.Value, CultureForNumberString, CultureForDateString);
+                    TransactionRows[pair.Value.Id].UpdateRow(pair.Value, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
                 }
                 else
                 {
@@ -687,7 +699,7 @@ public class AccountViewController : IDisposable
             {
                 if (pair.Value.RepeatFrom == -1)
                 {
-                    TransactionRows[pair.Value.Id].UpdateRow(pair.Value, CultureForNumberString, CultureForDateString);
+                    TransactionRows[pair.Value.Id].UpdateRow(pair.Value, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
                 }
                 else if (pair.Value.RepeatFrom == transaction.Id)
                 {
@@ -700,8 +712,8 @@ public class AccountViewController : IDisposable
                 TransactionRows.Remove(pair.Key);
             }
         }
-        GroupRows[originalGroupId].UpdateRow(_account.Groups[originalGroupId], CultureForNumberString, _filters[(int)originalGroupId]);
-        GroupRows[newGroupId].UpdateRow(_account.Groups[newGroupId], CultureForNumberString, _filters[(int)newGroupId]);
+        GroupRows[originalGroupId].UpdateRow(_account.Groups[originalGroupId], GroupDefaultColor, CultureForNumberString, _filters[(int)originalGroupId]);
+        GroupRows[newGroupId].UpdateRow(_account.Groups[newGroupId], GroupDefaultColor, CultureForNumberString, _filters[(int)newGroupId]);
         AccountTransactionsChanged?.Invoke(this, EventArgs.Empty);
         FilterUIUpdate();
     }
@@ -716,7 +728,7 @@ public class AccountViewController : IDisposable
         await _account.DeleteTransactionAsync(id);
         UIDeleteTransactionRow!(TransactionRows[id]);
         TransactionRows.Remove(id);
-        GroupRows[groupId].UpdateRow(_account.Groups[groupId], CultureForNumberString, _filters[(int)groupId]);
+        GroupRows[groupId].UpdateRow(_account.Groups[groupId], GroupDefaultColor, CultureForNumberString, _filters[(int)groupId]);
         AccountTransactionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -748,11 +760,11 @@ public class AccountViewController : IDisposable
             {
                 if (pair.Value.RepeatFrom == -1)
                 {
-                    TransactionRows[pair.Value.Id].UpdateRow(pair.Value, CultureForNumberString, CultureForDateString);
+                    TransactionRows[pair.Value.Id].UpdateRow(pair.Value, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
                 }
             }
         }
-        GroupRows[groupId].UpdateRow(_account.Groups[groupId], CultureForNumberString, _filters[(int)groupId]);
+        GroupRows[groupId].UpdateRow(_account.Groups[groupId], GroupDefaultColor, CultureForNumberString, _filters[(int)groupId]);
         AccountTransactionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -772,7 +784,7 @@ public class AccountViewController : IDisposable
             }
         }
         await _account.DeleteGeneratedTransactionsAsync(id);
-        GroupRows[groupId].UpdateRow(_account.Groups[groupId], CultureForNumberString, _filters[(int)groupId]);
+        GroupRows[groupId].UpdateRow(_account.Groups[groupId], GroupDefaultColor, CultureForNumberString, _filters[(int)groupId]);
         AccountTransactionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -812,14 +824,14 @@ public class AccountViewController : IDisposable
     public async Task UpdateGroupAsync(Group group, bool hasColorChanged)
     {
         await _account.UpdateGroupAsync(group);
-        GroupRows[group.Id].UpdateRow(group, CultureForNumberString, _filters[(int)group.Id]);
+        GroupRows[group.Id].UpdateRow(group, GroupDefaultColor, CultureForNumberString, _filters[(int)group.Id]);
         if(hasColorChanged)
         {
             foreach(var pair in _account.Transactions)
             {
                 if (pair.Value.GroupId == group.Id)
                 {
-                    TransactionRows[pair.Key].UpdateRow(pair.Value, CultureForNumberString.Parent, CultureForDateString);
+                    TransactionRows[pair.Key].UpdateRow(pair.Value, TransactionDefaultColor, CultureForNumberString.Parent, CultureForDateString);
                 }
             }
         }
@@ -913,7 +925,7 @@ public class AccountViewController : IDisposable
             {
                 var groupId = _account.Transactions[id].GroupId == -1 ? 0u : (uint)_account.Transactions[id].GroupId;
                 TransactionRows.Add(id, UICreateTransactionRow!(_account.Transactions[id], null));
-                GroupRows[groupId].UpdateRow(_account.Groups[groupId], CultureForNumberString, _filters[(int)groupId]);
+                GroupRows[groupId].UpdateRow(_account.Groups[groupId], GroupDefaultColor, CultureForNumberString, _filters[(int)groupId]);
             }
             FilterUIUpdate();
             SortUIUpdate();

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -843,7 +843,7 @@ public class AccountViewController : IDisposable
     /// <param name="id">The id of the group to delete</param>
     public async Task DeleteGroupAsync(uint id)
     {
-        var result = await _account.DeleteGroupAsync(id, TransactionDefaultColor);
+        var result = await _account.DeleteGroupAsync(id);
         _filters.Remove((int)id);
         UIDeleteGroupRow!(GroupRows[id]);
         GroupRows.Remove(id);

--- a/NickvisionMoney.Shared/Controllers/DashboardViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/DashboardViewController.cs
@@ -63,7 +63,7 @@ public class DashboardViewController
     /// </summary>
     /// <param name="localizer">The Localizer of the app</param>
     /// <param name="defaultColor">A default group color</param>
-    public DashboardViewController(List<AccountViewController> openAccounts, Localizer localizer, string defaultColor)
+    internal DashboardViewController(List<AccountViewController> openAccounts, Localizer localizer, string defaultColor)
     {
         _openAccounts = openAccounts;
         Localizer = localizer;

--- a/NickvisionMoney.Shared/Controllers/DashboardViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/DashboardViewController.cs
@@ -1,5 +1,4 @@
 ﻿using NickvisionMoney.Shared.Helpers;
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -101,9 +100,9 @@ public class DashboardViewController
                 }
                 Total.Breakdowns[currency] = (Total.Breakdowns[currency].Total + controller.AccountTodayTotal, Total.Breakdowns[currency].PerAccount + $"{string.Format(Localizer["AmountFromAccount"], controller.AccountTodayTotalString, controller.AccountTitle)}\n");
             }
-            foreach(var group in controller.Groups.Values)
+            foreach (var group in controller.Groups.Values)
             {
-                if(group.Balance != 0)
+                if (group.Balance != 0)
                 {
                     var name = group.Name.ToLower();
                     var nameBuilder = new StringBuilder(name);

--- a/NickvisionMoney.Shared/Controllers/GroupDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/GroupDialogController.cs
@@ -20,12 +20,9 @@ public enum GroupCheckStatus
 public class GroupDialogController
 {
     private string _originalName;
+    private string _originalRGBA;
     private readonly List<string> _existingNames;
 
-    /// <summary>
-    /// Gets the AppInfo object
-    /// </summary>
-    public AppInfo AppInfo => AppInfo.Current;
     /// <summary>
     /// The localizer to get translated strings from
     /// </summary>
@@ -40,6 +37,15 @@ public class GroupDialogController
     public bool IsEditing { get; init; }
 
     /// <summary>
+    /// Gets the AppInfo object
+    /// </summary>
+    public AppInfo AppInfo => AppInfo.Current;
+    /// <summary>
+    /// Whether or not the group color has changed
+    /// </summary>
+    public bool HasColorChanged => _originalRGBA != Group.RGBA;
+
+    /// <summary>
     /// Creates a GroupDialogController
     /// </summary>
     /// <param name="group">The Group object represented by the controller</param>
@@ -49,6 +55,7 @@ public class GroupDialogController
     internal GroupDialogController(Group group, List<string> existingNames, string groupDefaultColor, Localizer localizer)
     {
         _originalName = group.Name;
+        _originalRGBA = group.RGBA;
         _existingNames = existingNames;
         Localizer = localizer;
         Group = (Group)group.Clone();

--- a/NickvisionMoney.Shared/Controllers/GroupDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/GroupDialogController.cs
@@ -19,8 +19,8 @@ public enum GroupCheckStatus
 /// </summary>
 public class GroupDialogController
 {
-    private string _originalName;
-    private string _originalRGBA;
+    private readonly string _originalName;
+    private readonly string _originalRGBA;
     private readonly List<string> _existingNames;
 
     /// <summary>
@@ -76,6 +76,7 @@ public class GroupDialogController
     internal GroupDialogController(uint id, List<string> existingNames, string groupDefaultColor, Localizer localizer)
     {
         _originalName = "";
+        _originalRGBA = groupDefaultColor;
         _existingNames = existingNames;
         Localizer = localizer;
         Group = new Group(id);

--- a/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
@@ -120,7 +120,7 @@ public class TransactionDialogController : IDisposable
         CultureForDateString = cultureDate;
         if (string.IsNullOrEmpty(Transaction.RGBA))
         {
-            Transaction.RGBA = transactionDefaultColor;
+            Transaction.RGBA = _transactionDefaultColor;
         }
     }
 

--- a/NickvisionMoney.Shared/Controls/IGroupRowControl.cs
+++ b/NickvisionMoney.Shared/Controls/IGroupRowControl.cs
@@ -23,15 +23,17 @@ public interface IGroupRowControl : IModelRowControl<Group>
     /// Updates the row based on the new Group model
     /// </summary>
     /// <param name="group">The new Group model</param>
+    /// <param name="defaultColor">The default color for the row</param>
     /// <param name="cultureAmount">The culture to use for displaying amount strings</param>
     /// <param name="cultureDate">The culture to use for displaying date strings</param>
-    void IModelRowControl<Group>.UpdateRow(Group group, CultureInfo cultureAmount, CultureInfo cultureDate) => UpdateRow(group, cultureAmount, true);
+    void IModelRowControl<Group>.UpdateRow(Group group, string defaultColor, CultureInfo cultureAmount, CultureInfo cultureDate) => UpdateRow(group, defaultColor, cultureAmount, true);
 
     /// <summary>
     /// Updates the row based on the new Group model
     /// </summary>
     /// <param name="group">The new Group model</param>
+    /// <param name="defaultColor">The default color for the row</param>
     /// <param name="cultureAmount">The culture to use for displaying amount strings</param>
     /// <param name="filterActive">Whether or not the filter checkbox is active</param>
-    public void UpdateRow(Group group, CultureInfo cultureAmount, bool filterActive);
+    public void UpdateRow(Group group, string defaultColor, CultureInfo cultureAmount, bool filterActive);
 }

--- a/NickvisionMoney.Shared/Controls/IModelRowControl.cs
+++ b/NickvisionMoney.Shared/Controls/IModelRowControl.cs
@@ -37,7 +37,8 @@ public interface IModelRowControl<T>
     /// Updates the row based on the new model
     /// </summary>
     /// <param name="newModel">The new model T</param>
+    /// <param name="defaultColor">The default color for the row</param>
     /// <param name="cultureAmount">The culture to use for displaying amount strings</param>
     /// <param name="cultureDate">The culture to use for displaying date strings</param>
-    public void UpdateRow(T newModel, CultureInfo cultureAmount, CultureInfo cultureDate);
+    public void UpdateRow(T newModel, string defaultColor, CultureInfo cultureAmount, CultureInfo cultureDate);
 }

--- a/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
@@ -34,7 +34,8 @@ public static class CurrencyHelpers
                 0 => $"{culture.NumberFormat.CurrencySymbol}{{0}}",
                 1 => $"{{0}}{culture.NumberFormat.CurrencySymbol}",
                 2 => $"{culture.NumberFormat.CurrencySymbol} {{0}}",
-                3 => $"{{0}} {culture.NumberFormat.CurrencySymbol}"
+                3 => $"{{0}} {culture.NumberFormat.CurrencySymbol}",
+                _ => $"{culture.NumberFormat.CurrencySymbol}{{0}}"
             };
             result = string.Format(formatString, result);
         }

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -797,9 +797,8 @@ public class Account : IDisposable
     /// Deletes a group from the account
     /// </summary>
     /// <param name="id">The id of the group to delete</param>
-    /// <param name="defaultTransactionColor">A new transaction color for transactions belonging to deleted group</param>
     /// <returns>(Result, BelongingTransactions)</returns>
-    public async Task<(bool Result, List<uint> BelongingTransactions)> DeleteGroupAsync(uint id, string defaultTransactionColor)
+    public async Task<(bool Result, List<uint> BelongingTransactions)> DeleteGroupAsync(uint id)
     {
         using var cmdDeleteGroup = _database!.CreateCommand();
         cmdDeleteGroup.CommandText = "DELETE FROM groups WHERE id = $id";
@@ -820,7 +819,6 @@ public class Account : IDisposable
                     if (pair.Value.UseGroupColor)
                     {
                         pair.Value.UseGroupColor = false;
-                        pair.Value.RGBA = defaultTransactionColor;
                         belongingTransactions.Add(pair.Key);
                     }
                     await UpdateTransactionAsync(pair.Value);

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -17,7 +17,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Transactions;
 
 namespace NickvisionMoney.Shared.Models;
 
@@ -1773,7 +1772,7 @@ public class Account : IDisposable
     /// </summary>
     private void BackupAccountToCSV()
     {
-        if(!_isEncrypted.GetValueOrDefault())
+        if (!_isEncrypted.GetValueOrDefault())
         {
             ExportToCSV($"{Configuration.Current.CSVBackupFolder}{System.IO.Path.DirectorySeparatorChar}{Metadata.Name}.csv");
         }

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -1448,7 +1448,7 @@ public class Account : IDisposable
         }
         try
         {
-            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path));
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
             File.WriteAllText(path, result);
             return true;
         }
@@ -1468,7 +1468,7 @@ public class Account : IDisposable
     {
         try
         {
-            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path));
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
             using var localizer = new Localizer();
             //Amount Culture
             var lcMonetary = Environment.GetEnvironmentVariable("LC_MONETARY");

--- a/NickvisionMoney.WinUI/Controls/GroupRow.xaml.cs
+++ b/NickvisionMoney.WinUI/Controls/GroupRow.xaml.cs
@@ -7,7 +7,6 @@ using NickvisionMoney.Shared.Models;
 using NickvisionMoney.WinUI.Helpers;
 using System;
 using System.Globalization;
-using Windows.UI;
 
 namespace NickvisionMoney.WinUI.Controls;
 
@@ -17,7 +16,6 @@ namespace NickvisionMoney.WinUI.Controls;
 public sealed partial class GroupRow : UserControl, IGroupRowControl
 {
     private CultureInfo _cultureAmount;
-    private Color _defaultColor;
 
     /// <summary>
     /// The Id of the Group the row represents
@@ -44,18 +42,17 @@ public sealed partial class GroupRow : UserControl, IGroupRowControl
     /// <param name="cultureAmount">The CultureInfo to use for the amount string</param>
     /// <param name="localizer">The Localizer for the app</param>
     /// <param name="filterActive">Whether or not the filter checkbutton should be active</param>
-    /// <param name="defaultColor">The default group color</param>
-    public GroupRow(Group group, CultureInfo cultureAmount, Localizer localizer, bool filterActive, Color defaultColor)
+    /// <param name="defaultColor">The default color for the row</param>
+    public GroupRow(Group group, CultureInfo cultureAmount, Localizer localizer, bool filterActive, string defaultColor)
     {
         InitializeComponent();
         _cultureAmount = cultureAmount;
-        _defaultColor = defaultColor;
         //Localize Strings
         MenuEdit.Text = localizer["Edit", "GroupRow"];
         MenuDelete.Text = localizer["Delete", "GroupRow"];
         ToolTipService.SetToolTip(BtnEdit, localizer["Edit", "GroupRow"]);
         ToolTipService.SetToolTip(BtnDelete, localizer["Delete", "GroupRow"]);
-        UpdateRow(group, cultureAmount, filterActive);
+        UpdateRow(group, defaultColor, cultureAmount, filterActive);
     }
 
     /// <summary>
@@ -82,9 +79,10 @@ public sealed partial class GroupRow : UserControl, IGroupRowControl
     /// Updates the row with the new model
     /// </summary>
     /// <param name="group">The new Group model</param>
+    /// <param name="defaultColor">The default color for the row</param>
     /// <param name="cultureAmount">The culture to use for displaying amount strings</param>
     /// <param name="filterActive">Whether or not the filter checkbox is active</param>
-    public void UpdateRow(Group group, CultureInfo cultureAmount, bool filterActive)
+    public void UpdateRow(Group group, string defaultColor, CultureInfo cultureAmount, bool filterActive)
     {
         Id = group.Id;
         _cultureAmount = cultureAmount;
@@ -95,7 +93,7 @@ public sealed partial class GroupRow : UserControl, IGroupRowControl
             MenuDelete.IsEnabled = false;
             BtnDelete.Visibility = Visibility.Collapsed;
         }
-        BtnId.Background = new SolidColorBrush(ColorHelpers.FromRGBA(group.RGBA) ?? _defaultColor);
+        BtnId.Background = new SolidColorBrush(ColorHelpers.FromRGBA(group.RGBA) ?? ColorHelpers.FromRGBA(defaultColor)!.Value);
         ChkFilter.IsChecked = filterActive;
         LblName.Text = group.Name;
         LblDescription.Visibility = string.IsNullOrEmpty(group.Description) ? Visibility.Collapsed : Visibility.Visible;

--- a/NickvisionMoney.WinUI/Controls/TransactionRow.xaml.cs
+++ b/NickvisionMoney.WinUI/Controls/TransactionRow.xaml.cs
@@ -8,7 +8,6 @@ using NickvisionMoney.WinUI.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Windows.UI;
 
 namespace NickvisionMoney.WinUI.Controls;
 
@@ -19,7 +18,6 @@ public sealed partial class TransactionRow : UserControl, IModelRowControl<Trans
 {
     private CultureInfo _cultureAmount;
     private CultureInfo _cultureDate;
-    private Color _defaultColor;
     private Localizer _localizer;
     private int _repeatFrom;
     private Dictionary<uint, Group> _groups;
@@ -49,14 +47,13 @@ public sealed partial class TransactionRow : UserControl, IModelRowControl<Trans
     /// <param name="groups">The groups in the account</param>
     /// <param name="cultureAmount">The CultureInfo to use for the amount string</param>
     /// <param name="cultureDate">The CultureInfo to use for the date string</param>
-    /// <param name="defaultColor">The default transaction color</param>
+    /// <param name="defaultColor">The default color for the row</param>
     /// <param name="localizer">The Localizer for the app</param>
-    public TransactionRow(Transaction transaction, Dictionary<uint, Group> groups, CultureInfo cultureAmount, CultureInfo cultureDate, Color defaultColor, Localizer localizer)
+    public TransactionRow(Transaction transaction, Dictionary<uint, Group> groups, CultureInfo cultureAmount, CultureInfo cultureDate, string defaultColor, Localizer localizer)
     {
         InitializeComponent();
         _cultureAmount = cultureAmount;
         _cultureDate = cultureDate;
-        _defaultColor = defaultColor;
         _localizer = localizer;
         _repeatFrom = 0;
         _groups = groups;
@@ -65,7 +62,7 @@ public sealed partial class TransactionRow : UserControl, IModelRowControl<Trans
         MenuDelete.Text = _localizer["Delete", "TransactionRow"];
         ToolTipService.SetToolTip(BtnEdit, _localizer["Edit", "TransactionRow"]);
         ToolTipService.SetToolTip(BtnDelete, _localizer["Delete", "TransactionRow"]);
-        UpdateRow(transaction, cultureAmount, cultureDate);
+        UpdateRow(transaction, defaultColor, cultureAmount, cultureDate);
     }
 
     /// <summary>
@@ -82,9 +79,10 @@ public sealed partial class TransactionRow : UserControl, IModelRowControl<Trans
     /// Updates the row with the new model
     /// </summary>
     /// <param name="transaction">The new Transaction model</param>
+    /// <param name="defaultColor">The default color for the row</param>
     /// <param name="cultureAmount">The culture to use for displaying amount strings</param>
     /// <param name="cultureDate">The culture to use for displaying date strings</param>
-    public void UpdateRow(Transaction transaction, CultureInfo cultureAmount, CultureInfo cultureDate)
+    public void UpdateRow(Transaction transaction, string defaultColor, CultureInfo cultureAmount, CultureInfo cultureDate)
     {
         Id = transaction.Id;
         _repeatFrom = transaction.RepeatFrom;
@@ -95,7 +93,7 @@ public sealed partial class TransactionRow : UserControl, IModelRowControl<Trans
         MenuDelete.IsEnabled = _repeatFrom <= 0;
         BtnDelete.Visibility = _repeatFrom <= 0 ? Visibility.Visible : Visibility.Collapsed;
         BtnId.Content = transaction.Id;
-        BtnId.Background = new SolidColorBrush(ColorHelpers.FromRGBA(transaction.UseGroupColor ? _groups[transaction.GroupId <= 0 ? 0u : (uint)transaction.GroupId].RGBA : transaction.RGBA) ?? _defaultColor);
+        BtnId.Background = new SolidColorBrush(ColorHelpers.FromRGBA(transaction.UseGroupColor ? _groups[transaction.GroupId <= 0 ? 0u : (uint)transaction.GroupId].RGBA : transaction.RGBA) ?? ColorHelpers.FromRGBA(defaultColor)!.Value);
         LblName.Text = transaction.Description;
         LblDescription.Text = transaction.Date.ToString("d", _cultureDate);
         if (transaction.RepeatInterval != TransactionRepeatInterval.Never)

--- a/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
@@ -119,7 +119,7 @@ public sealed partial class AccountView : UserControl, INotifyPropertyChanged
     /// <returns>The IGroupRowControl</returns>
     private IGroupRowControl CreateGroupRow(Group group, int? index)
     {
-        var row = new GroupRow(group, _controller.CultureForNumberString, _controller.Localizer, _controller.IsFilterActive(group.Id == 0 ? -1 : (int)group.Id), ColorHelpers.FromRGBA(_controller.GroupDefaultColor) ?? Color.FromArgb(255, 0, 0, 0));
+        var row = new GroupRow(group, _controller.CultureForNumberString, _controller.Localizer, _controller.IsFilterActive(group.Id == 0 ? -1 : (int)group.Id), _controller.GroupDefaultColor);
         row.EditTriggered += EditGroup;
         row.DeleteTriggered += DeleteGroup;
         row.FilterChanged += UpdateGroupFilter;
@@ -149,7 +149,7 @@ public sealed partial class AccountView : UserControl, INotifyPropertyChanged
     private IModelRowControl<Transaction> CreateTransactionRow(Transaction transaction, int? index)
     {
         ViewStackTransactions.ChangePage("Transactions");
-        var row = new TransactionRow(transaction, _controller.Groups, _controller.CultureForNumberString, _controller.CultureForDateString, ColorHelpers.FromRGBA(_controller.TransactionDefaultColor) ?? Color.FromArgb(255, 0, 0, 0), _controller.Localizer);
+        var row = new TransactionRow(transaction, _controller.Groups, _controller.CultureForNumberString, _controller.CultureForDateString, _controller.TransactionDefaultColor, _controller.Localizer);
         row.EditTriggered += EditTransaction;
         row.DeleteTriggered += DeleteTransaction;
         if (index != null)

--- a/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
@@ -575,7 +575,7 @@ public sealed partial class AccountView : UserControl, INotifyPropertyChanged
             LoadingCtrl.IsLoading = true;
             //Work
             await Task.Delay(50);
-            await _controller.UpdateGroupAsync(groupController.Group);
+            await _controller.UpdateGroupAsync(groupController.Group, groupController.HasColorChanged);
             //Done Loading
             LoadingCtrl.IsLoading = false;
         }

--- a/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/AccountView.xaml.cs
@@ -10,7 +10,6 @@ using NickvisionMoney.Shared.Controls;
 using NickvisionMoney.Shared.Events;
 using NickvisionMoney.Shared.Models;
 using NickvisionMoney.WinUI.Controls;
-using NickvisionMoney.WinUI.Helpers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/NickvisionMoney.WinUI/Views/DashboardPage.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/DashboardPage.xaml.cs
@@ -1,13 +1,13 @@
+using CommunityToolkit.WinUI.UI.Controls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using NickvisionMoney.Shared.Controllers;
-using System.Globalization;
-using System;
-using Windows.UI;
 using NickvisionMoney.Shared.Helpers;
-using CommunityToolkit.WinUI.UI.Controls;
 using NickvisionMoney.WinUI.Helpers;
+using System;
+using System.Globalization;
+using Windows.UI;
 
 namespace NickvisionMoney.WinUI.Views;
 

--- a/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
@@ -109,7 +109,7 @@ public sealed partial class TransactionDialog : ContentDialog, INotifyPropertyCh
             CalendarRepeatEndDate.Date = new DateTimeOffset(new DateTime(_controller.Transaction.RepeatEndDate.Value.Year, _controller.Transaction.RepeatEndDate.Value.Month, _controller.Transaction.RepeatEndDate.Value.Day));
         }
         _selectedColor = (Color)ColorHelpers.FromRGBA(_controller.Transaction.RGBA)!;
-        if(_controller.Transaction.GroupId > 0)
+        if (_controller.Transaction.GroupId > 0)
         {
             CmbColor.Visibility = Visibility.Visible;
             CmbColor.SelectedIndex = _controller.Transaction.UseGroupColor ? 0 : 1;
@@ -288,7 +288,7 @@ public sealed partial class TransactionDialog : ContentDialog, INotifyPropertyCh
         if (!_constructing)
         {
             CmbColor.Visibility = (string)CmbGroup.SelectedItem != _controller.Localizer["Ungrouped"] ? Visibility.Visible : Visibility.Collapsed;
-            if(CmbColor.Visibility == Visibility.Visible)
+            if (CmbColor.Visibility == Visibility.Visible)
             {
                 _constructing = true;
                 CmbColor.SelectedIndex = _controller.Transaction.UseGroupColor ? 0 : 1;


### PR DESCRIPTION
This PR fixes an issue where transactions using a group's color would not update when said group's color was changed. This PR also includes a change that updates the `Ungrouped` row's color when it is changed in the configuration.

Closes #429 