### PR TITLE
Default to group color on selecting group

### DIFF
--- a/NickvisionMoney.GNOME/Views/TransactionDialog.cs
+++ b/NickvisionMoney.GNOME/Views/TransactionDialog.cs
@@ -231,6 +231,10 @@ public partial class TransactionDialog : Adw.Window
                 {
                     _colorDropDown.SetSelected(1);
                 }
+                else if (!_colorDropDown.GetVisible())
+                {
+                    _colorDropDown.SetSelected(0);
+                }
                 _colorDropDown.SetVisible(_groupRow.GetSelected() != 0);
                 if (!_constructing)
                 {

--- a/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
@@ -118,6 +118,7 @@ public sealed partial class TransactionDialog : ContentDialog, INotifyPropertyCh
         else
         {
             CmbColor.Visibility = Visibility.Collapsed;
+            CmbColor.SelectedIndex = 0;
             BtnColor.Visibility = Visibility.Visible;
         }
         BtnReceiptView.IsEnabled = _controller.Transaction.Receipt != null;


### PR DESCRIPTION
- [x] GNOME
- [x] Windows @nlogozzo 

It probably makes far more sense to default to group colors