### PR TITLE
Revert "Default to group color on selecting group"

### DIFF
--- a/NickvisionMoney.GNOME/Views/TransactionDialog.cs
+++ b/NickvisionMoney.GNOME/Views/TransactionDialog.cs
@@ -231,10 +231,6 @@ public partial class TransactionDialog : Adw.Window
                 {
                     _colorDropDown.SetSelected(1);
                 }
-                else if (!_colorDropDown.GetVisible())
-                {
-                    _colorDropDown.SetSelected(0);
-                }
                 _colorDropDown.SetVisible(_groupRow.GetSelected() != 0);
                 if (!_constructing)
                 {

--- a/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
+++ b/NickvisionMoney.WinUI/Views/TransactionDialog.xaml.cs
@@ -118,7 +118,6 @@ public sealed partial class TransactionDialog : ContentDialog, INotifyPropertyCh
         else
         {
             CmbColor.Visibility = Visibility.Collapsed;
-            CmbColor.SelectedIndex = 0;
             BtnColor.Visibility = Visibility.Visible;
         }
         BtnReceiptView.IsEnabled = _controller.Transaction.Receipt != null;


### PR DESCRIPTION
I disagree with the change in #431. What is the benefit? I don't understand for what scenarios it is an improvement. But what if a user selects unique color first and then selects a group? Or simply wants to change a group for an existing transaction without changing color? Now it requires additional actions to achieve the goal.